### PR TITLE
fix default display

### DIFF
--- a/src/view/alert/Condition.vue
+++ b/src/view/alert/Condition.vue
@@ -737,7 +737,7 @@ export default {
         description:'', 
         severity:'', 
         and_or:'',
-        enabled:false,
+        enabled:true,
         rules: [],
         notifications: [],
         updated_at:''

--- a/src/view/alert/Rule.vue
+++ b/src/view/alert/Rule.vue
@@ -402,7 +402,7 @@ export default {
 
     // handler
     handleNewItem() {
-      this.dataModel = { alert_rule_id:0, name:'', score:0, resource_name: '', tag:'', finding_cnt:0, updated_at:'' }
+      this.dataModel = { alert_rule_id:0, name:'', score:0.6, resource_name: '', tag:'', finding_cnt:1, updated_at:'' }
       this.form.new = true
       this.editDialog  = true
     },


### PR DESCRIPTION
アラートの新規作成画面のデフォルト表示を修正
- （アラートルール）Findingの数=1をプリセット
- （アラートルール）スコアを0.6をプリセット
- （アラート条件）enabled = trueをプリセット
