### PR TITLE
wait after tagging for project

### DIFF
--- a/src/view/project/Setting.vue
+++ b/src/view/project/Setting.vue
@@ -227,6 +227,7 @@ export default {
       }
       this.loading = true
       await this.tagProject()
+      await new Promise(resolve => setTimeout(resolve, 1000))
       await this.setProject()
       this.loading = false
       this.tagDialog = false


### PR DESCRIPTION
プロジェクトタグの追加のあと1秒のウェイトを入れます
（slaveへの反映を待つという意味で、、、。APIを改修してmaster側に問い合わせする選択もありますが、list-projectのAPIはよく叩かれるのでシステム全体影響少ない方で一旦しのぎたいと思います。）