### PR TITLE
fix project id process

### DIFF
--- a/src/component/AppToolbar.vue
+++ b/src/component/AppToolbar.vue
@@ -327,9 +327,9 @@ export default {
     handleGoBack() {
       this.$router.go(-1)
     },
-    handleProjectClick(project)  {
-      this.clearProjectQueryParam()
-      store.commit('updateProject', project)
+    async handleProjectClick(project)  {
+      await this.setProjectQueryParam(project.project_id)
+      await store.commit('updateProject', project)
       this.reload()
     },
     handleNewProject() {
@@ -340,10 +340,11 @@ export default {
       this.projectDialog = true
       this.listProject()
     },
-    clearProjectQueryParam() {
-      let query = Object.assign({}, this.$router.query)
-      delete query["project_id"]
-      this.$router.query = query
+    async setProjectQueryParam(project_id) {
+      let query = await Object.assign({}, this.$router.query)
+      // delete query["project_id"]
+      query.project_id = project_id
+      await this.$router.push({query: query})
     },
   },
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,7 +22,7 @@ router.beforeEach( async (to, from, next) => {
   const project_id = to.query.project_id
   const current_project_id = store.state.project.project_id 
   const user_id = store.state.user.user_id
-  if ( typeof project_id != 'undefined' && typeof user_id != 'undefined' && project_id !== current_project_id ) {
+  if ( typeof project_id != 'undefined' && typeof user_id != 'undefined' && project_id != current_project_id ) {
     const admin = await axios.get('/iam/is-admin/?user_id=' + user_id )
     let q = 'project_id=' + project_id
     if ( !admin.data.data.ok ) {
@@ -30,8 +30,12 @@ router.beforeEach( async (to, from, next) => {
     }
     const res = await axios.get('/project/list-project/?' + q )
     if ( res.data.data.project ) {
-      store.commit('updateProject', res.data.data.project[0])
-      next({path: to.currentRoute, force: true})
+      await store.commit('updateProject', res.data.data.project[0])
+      // let query = Object.assign({}, to.query)
+      // delete query["project_id"]
+      // router.push({query: query}) // Edit query parameter
+      router.go({path: to.currentRoute})
+      next(false)
     }
   }
   next()


### PR DESCRIPTION
#105 の対応でプロジェクト切り替えの挙動を少しだけ変えます。
vue-routerのグローバルナビゲーションで、常にstoreとqueryのプロジェクトを参照して整合性を保ちます。
ただし、以下の優先順位で処理を行います。

- Query prameterで `project_id` が設定されていたら、それを優先にプロジェクト切り替えを行う（storeの値も更新）
- 設定されていなかったら、storeの値を参照する
- ~~画面上からプロジェクト切り替えを行った場合は、Query prameterで `project_id` を付与する~~