### PR TITLE
increase timeout milli sec

### DIFF
--- a/src/axios/index.js
+++ b/src/axios/index.js
@@ -3,7 +3,7 @@ import router from '../router'
 
 const axios = Axios.create({
   baseURL: '/api/v1',
-  timeout: 10000,
+  timeout: 20000,
 })
 axios.interceptors.request.use(
   config => {


### PR DESCRIPTION
あるプロジェクトのリソース画面で、データが数十万件あって、表示に10秒以上かかってしまっていました。
timeout設定を一旦引き伸ばします