### PR TITLE
fix bug

### DIFF
--- a/src/component/AppToolbar.vue
+++ b/src/component/AppToolbar.vue
@@ -149,7 +149,11 @@
           </v-data-table>
         </v-card-text>
         <v-card-actions>
-          <v-btn text outlined color="blue darken-1" @click="$router.push('/project/setting/'); projectDialog = false">
+          <v-btn 
+            text outlined color="blue darken-1"
+            v-if="currentProjectID"
+            @click="$router.push('/project/setting/'); projectDialog = false"
+          >
             {{ $t(`btn['EDIT PROJECT']`) }}
           </v-btn>
           <v-spacer />
@@ -192,6 +196,7 @@ export default {
         },
         item: [],
       },
+      currentProjectID: '',
       availableLanguages: [
         {text: "English", value : "en"},
         {text: "日本語",   value : "ja"},
@@ -250,6 +255,7 @@ export default {
     },
   },
   mounted() {
+    this.currentProjectID = store.state.project.project_id
     const userLocale = store.state.locale
     if (userLocale.lang && userLocale.text) {
       this.handleChangeLocale({

--- a/src/view/project/Setting.vue
+++ b/src/view/project/Setting.vue
@@ -173,6 +173,9 @@ export default {
   },
   methods: {
     async setProject() {
+      if (!store.state.project.project_id ) {
+        return
+      }
       this.projectModel = store.state.project
       const param = '?project_id=' + this.projectModel.project_id
       const project = await this.listProjectAPI(param).catch((err) =>  {


### PR DESCRIPTION
プロジェクトを設定してない状態で、 /project/setting 画面に行くと、別プロジェクトのタグが表示されてしまうバグがありました。
- バグの修正
- プロジェクト選択してない時は、そもそもプロジェクト編集画面への導線（ボタン）を消す