### PR TITLE
fix notification

### DIFF
--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -1,4 +1,5 @@
 import Util from '@/util'
+const maskedPattern = /\*.*$/
 let mixin = {
   data: () => {
     return {
@@ -35,6 +36,12 @@ let mixin = {
     },
     cutString: (str) => {
       return Util.cutLongString(str, 10)
+    },
+    formatSmartMaskString: (masked) => {
+      if (!masked) {
+        return ''
+      }
+      return masked.replace(maskedPattern, '*****')
     },
   },
   methods: {

--- a/src/view/alert/Notification.vue
+++ b/src/view/alert/Notification.vue
@@ -139,7 +139,7 @@
               <p class="text-caption">
                 {{ $t(`view.alert['Currently, the following webhook URL (masked) is registered. Please enter the webhook URL again.']`) }}
               </p>
-              <p>{{ dataModel.masked_webhook_url }}</p>
+              <p>{{ dataModel.masked_webhook_url | formatSmartMaskString }}</p>
             </v-alert>
 
             <v-checkbox


### PR DESCRIPTION
アラート画面で実際のwebhookURLはかなり長くなってしまっていて表示崩れが発生してました。
URLはマスクされてた文字列なので、マスク部分を短くして、画面に収めるように調整します