### PR TITLE
fix project change bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "deepmerge": "^4.2.2",
     "eslint": "^7.8.1",
     "eslint-plugin-vue": "^6.2.2",
-    "fibers": "^5.0.0",
     "sass": "^1.26.10",
     "sass-loader": "^10.0.2",
     "vue-cli-plugin-vuetify": "~2.0.7",

--- a/src/component/AppToolbar.vue
+++ b/src/component/AppToolbar.vue
@@ -11,7 +11,8 @@
         <template v-slot:activator="{ on }">
           <!-- Project -->
           <v-btn
-            text dark
+            text
+            dark
             slot="activator"
             v-on="on"
             class="pa-0 ml-4"
@@ -23,9 +24,11 @@
                 <v-avatar tile size="42">
                   <v-icon x-large>mdi-alpha-p-box</v-icon>
                 </v-avatar>
-                <v-layout align-center justify-center
+                <v-layout
+                  align-center
+                  justify-center
                   class="text-h5 ml-4 font-weight-black"
-                  style="text-decoration: underline;"
+                  style="text-decoration: underline"
                 >
                   {{ projectName }}
                 </v-layout>
@@ -85,7 +88,7 @@
             rel="noopener"
             :key="index"
           >
-            <v-list-item-action v-if="item.icon"  class="mr-4">
+            <v-list-item-action v-if="item.icon" class="mr-4">
               <v-icon>{{ item.icon }}</v-icon>
             </v-list-item-action>
             <v-list-item-content>
@@ -105,12 +108,18 @@
     </v-toolbar>
 
     <!-- Project dialog -->
-    <v-dialog max-width="64%" v-model="projectDialog" @click:outside="projectDialog = false">
+    <v-dialog
+      max-width="64%"
+      v-model="projectDialog"
+      @click:outside="projectDialog = false"
+    >
       <v-card>
         <v-card-title>
           <span class="mx-2"> Project </span>
           <v-text-field
-            outlined clearable dense
+            outlined
+            clearable
+            dense
             prepend-icon="mdi-magnify"
             placeholder="Type something..."
             v-model="projectTable.search"
@@ -141,7 +150,8 @@
                 :key="t.tag"
                 :color="t.color"
                 class="ma-1"
-                dark link
+                dark
+                link
               >
                 {{ t.tag }}
               </v-chip>
@@ -149,18 +159,36 @@
           </v-data-table>
         </v-card-text>
         <v-card-actions>
-          <v-btn 
-            text outlined color="blue darken-1"
+          <v-btn
+            text
+            outlined
+            color="blue darken-1"
             v-if="currentProjectID"
-            @click="$router.push('/project/setting/'); projectDialog = false"
+            @click="
+              $router.push('/project/setting/')
+              projectDialog = false
+            "
           >
             {{ $t(`btn['EDIT PROJECT']`) }}
           </v-btn>
           <v-spacer />
-          <v-btn text outlined color="grey darken-1" @click="projectDialog = false">
+          <v-btn
+            text
+            outlined
+            color="grey darken-1"
+            @click="projectDialog = false"
+          >
             {{ $t(`btn['CANCEL']`) }}
           </v-btn>
-          <v-btn text outlined color="green darken-1" @click="$router.push('/project/new/'); projectDialog = false">
+          <v-btn
+            text
+            outlined
+            color="green darken-1"
+            @click="
+              $router.push('/project/new/')
+              projectDialog = false
+            "
+          >
             {{ $t(`btn['CREATE NEW PROJECT']`) }}
           </v-btn>
         </v-card-actions>
@@ -170,13 +198,13 @@
   </v-app-bar>
 </template>
 <script>
-import BottomSnackBar from '@/component/widget/snackbar/BottomSnackBar'
-import Util from '@/util'
-import store from '@/store'
-import mixin from '@/mixin'
-import project from '@/mixin/api/project'
+import BottomSnackBar from "@/component/widget/snackbar/BottomSnackBar"
+import Util from "@/util"
+import store from "@/store"
+import mixin from "@/mixin"
+import project from "@/mixin/api/project"
 export default {
-  name: 'AppToolbar',
+  name: "AppToolbar",
   components: {
     // ProjectList,
     BottomSnackBar,
@@ -185,10 +213,10 @@ export default {
   data() {
     return {
       loading: false,
-      projectDialog:false,
+      projectDialog: false,
       projectTable: {
-        search: '',
-        options: { page: 1, itemsPerPage: 10, sortBy: ['project_id'] },
+        search: "",
+        options: { page: 1, itemsPerPage: 10, sortBy: ["project_id"] },
         footer: {
           itemsPerPageOptions: [10],
           showCurrentPage: true,
@@ -196,40 +224,58 @@ export default {
         },
         item: [],
       },
-      currentProjectID: '',
+      currentProjectID: "",
       availableLanguages: [
-        {text: "English", value : "en"},
-        {text: "日本語",   value : "ja"},
+        { text: "English", value: "en" },
+        { text: "日本語", value: "ja" },
       ],
 
       myMenus: [
         {
-          icon: 'mdi-account-circle',
-          href: '#',
-          title: 'Account',
+          icon: "mdi-account-circle",
+          href: "#",
+          title: "Account",
           click: this.handleAccountSetting,
         },
         {
-          icon: 'mdi-alpha-p-box',
-          href: '#',
-          title: 'My Project',
+          icon: "mdi-alpha-p-box",
+          href: "#",
+          title: "My Project",
           click: this.handleProjectSetting,
         },
         {
-          icon: 'mdi-logout',
-          href: '#',
-          title: 'Signout',
+          icon: "mdi-logout",
+          href: "#",
+          title: "Signout",
           click: this.handleLogut,
         },
-      ]
+      ],
     }
   },
   computed: {
     headers() {
       return [
-        { text: this.$i18n.t('item["ID"]'),   align: 'start',  width: '5%',  sortable: true, value: 'project_id' },
-        { text: this.$i18n.t('item["Name"]'), align: 'start',  width: '25%', sortable: true, value: 'name' },
-        { text: this.$i18n.t('item["Tag"]'),  align: 'start', width: '70%',  sortable: true, value: 'tag' },
+        {
+          text: this.$i18n.t('item["ID"]'),
+          align: "start",
+          width: "5%",
+          sortable: true,
+          value: "project_id",
+        },
+        {
+          text: this.$i18n.t('item["Name"]'),
+          align: "start",
+          width: "25%",
+          sortable: true,
+          value: "name",
+        },
+        {
+          text: this.$i18n.t('item["Tag"]'),
+          align: "start",
+          width: "70%",
+          sortable: true,
+          value: "tag",
+        },
       ]
     },
     toolbarColor() {
@@ -246,7 +292,7 @@ export default {
           text: route.meta.title,
           to: to,
           exact: true,
-          disabled: false
+          disabled: false,
         }
       })
     },
@@ -260,38 +306,48 @@ export default {
     if (userLocale.lang && userLocale.text) {
       this.handleChangeLocale({
         value: userLocale.lang,
-        text:  userLocale.text
+        text: userLocale.text,
       })
       return
     }
     const browserLocale = Util.getNavigatorLanguage()
     this.handleChangeLocale({
       value: browserLocale,
-      text:  this.getLocaleText(browserLocale)
+      text: this.getLocaleText(browserLocale),
     })
   },
   methods: {
-    customFilter (value, search) {
-      return value != null &&
+    customFilter(value, search) {
+      return (
+        value != null &&
         search != null &&
-        typeof value !== 'boolean' &&
-        (typeof value === 'object' ? value.map(v => v.tag).join(',') : value)
-          .toString().toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
+        typeof value !== "boolean" &&
+        (typeof value === "object" ? value.map((v) => v.tag).join(",") : value)
+          .toString()
+          .toLocaleLowerCase()
+          .indexOf(search.toLocaleLowerCase()) !== -1
+      )
     },
     async listProject() {
       this.clearProjectList()
-      if ( !store.state.user || !store.state.user.user_id ) {
-        this.$refs.snackbar.notifyError( 'Error: Try again after signin.' )
+      await this.signinUser()
+      if (!store.state.user || !store.state.user.user_id) {
+        // this.$refs.snackbar.notifyError("Error: Try again after signin.")
+        console.log("Error: Try again after signin.")
         return
       }
-      const admin = await this.$axios.get('/iam/is-admin/?user_id=' + store.state.user.user_id ).catch((err) =>  {
-        return Promise.reject(err)
-      })
-      let listProjectParam = '?user_id=' + store.state.user.user_id
+      const admin = await this.$axios
+        .get("/iam/is-admin/?user_id=" + store.state.user.user_id)
+        .catch((err) => {
+          return Promise.reject(err)
+        })
+      let listProjectParam = "?user_id=" + store.state.user.user_id
       if (admin.data.data.ok) {
-        listProjectParam = ''
+        listProjectParam = ""
       }
-      this.projectTable.item = await this.listProjectAPI(listProjectParam).catch((err) =>  {
+      this.projectTable.item = await this.listProjectAPI(
+        listProjectParam
+      ).catch((err) => {
         return Promise.reject(err)
       })
       this.loading = false
@@ -301,20 +357,20 @@ export default {
     },
 
     getLocaleText(locale) {
-      if (typeof locale !== 'string' || locale ===  '') return '?'
+      if (typeof locale !== "string" || locale === "") return "?"
       switch (locale.toLowerCase()) {
-        case 'en':
-          return 'English'
-        case 'ja':
-          return '日本語'
+        case "en":
+          return "English"
+        case "ja":
+          return "日本語"
         default:
-          return '?'
+          return "?"
       }
     },
 
     // handler
     handleDrawerToggle() {
-      this.$emit('side-icon-click')
+      this.$emit("side-icon-click")
     },
     handleFullScreen() {
       Util.toggleFullScreen()
@@ -325,27 +381,27 @@ export default {
         text: item.text,
       }
       this.$i18n.locale = item.value
-      store.commit('updateLocale', locale)
+      store.commit("updateLocale", locale)
     },
     handleLogut() {
-      this.$router.push('/auth/signin/')
+      this.$router.push("/auth/signin/")
     },
     handleAccountSetting() {
-      this.$router.push('/iam/profile/')
+      this.$router.push("/iam/profile/")
     },
     handleProjectSetting() {
-      this.$router.push('/project/setting/')
+      this.$router.push("/project/setting/")
     },
     handleGoBack() {
       this.$router.go(-1)
     },
-    async handleProjectClick(project)  {
+    async handleProjectClick(project) {
       await this.setProjectQueryParam(project.project_id)
-      await store.commit('updateProject', project)
+      await store.commit("updateProject", project)
       this.reload()
     },
     handleNewProject() {
-      this.$router.push('/project/new')
+      this.$router.push("/project/new")
     },
     handleSearchProject() {
       this.loading = true
@@ -356,7 +412,7 @@ export default {
       let query = await Object.assign({}, this.$router.query)
       // delete query["project_id"]
       query.project_id = project_id
-      await this.$router.push({query: query})
+      await this.$router.push({ query: query })
     },
   },
 }

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -1,4 +1,5 @@
 import Util from '@/util'
+import store from "@/store"
 const maskedPattern = /\*.*$/
 let mixin = {
   data: () => {
@@ -27,7 +28,7 @@ let mixin = {
   },
   filters: {
     formatTime: (unix) => {
-      if (unix === '0' ) {
+      if (unix === '0') {
         return '-'
       }
       return Util.formatDate(new Date(unix * 1000), 'yyyy/MM/dd HH:mm')
@@ -46,8 +47,20 @@ let mixin = {
     },
   },
   methods: {
+    async signinUser() {
+      await store.commit("storeUser", {})
+      const userID = await this.signin().catch((err) => {
+        return Promise.reject(err)
+      })
+      const user = await this.$axios
+        .get("/iam/get-user?user_id=" + userID)
+        .catch((err) => {
+          return Promise.reject(err)
+        })
+      await store.commit("storeUser", user.data.data.user)
+    },
     async signin() {
-      const res = await this.$axios.get('/signin/').catch((err) =>  {
+      const res = await this.$axios.get('/signin/').catch((err) => {
         return Promise.reject(err)
       })
       if (!res.data.user_id) {
@@ -55,40 +68,40 @@ let mixin = {
       }
       return res.data.user_id
     },
-    reload: function() {
-      this.$router.go({path: this.$router.currentRoute.path, force: true})
+    reload: function () {
+      this.$router.go({ path: this.$router.currentRoute.path, force: true })
     },
     getColorByCount(cnt) {
-      if ( cnt == 0 ) {
+      if (cnt == 0) {
         return 'grey lighten-1'
-      } else if ( cnt <= 10 ) {
+      } else if (cnt <= 10) {
         return 'teal lighten-2'
-      } else if ( cnt <= 30 ) {
+      } else if (cnt <= 30) {
         return 'yellow darken-3'
       } else {
         return 'red darken-2'
       }
     },
     getColorByScore: (score) => {
-      if ( score < 0.6 ) {
+      if (score < 0.6) {
         return 'teal lighten-2'
-      } else if ( score < 0.8 ) {
+      } else if (score < 0.8) {
         return 'yellow darken-3'
       } else {
         return 'red darken-2'
       }
     },
     getColorRGBByScore: (score) => {
-      if ( score < 0.6 ) {
+      if (score < 0.6) {
         return '#4DB6AC'
-      } else if ( score < 0.8 ) {
+      } else if (score < 0.8) {
         return '#F9A825'
       } else {
         return '#D32F2F'
       }
     },
     getColorByFindingStatus(status) {
-      if (typeof status !== 'string' || status ===  '') return 'grey'
+      if (typeof status !== 'string' || status === '') return 'grey'
       switch (status.toLocaleUpperCase()) {
         case 'ACTIVE':
           return 'success'
@@ -99,7 +112,7 @@ let mixin = {
       }
     },
     getSeverityColor: (severity) => {
-      if (typeof severity !== 'string' || severity ===  '') return ''
+      if (typeof severity !== 'string' || severity === '') return ''
       switch (severity.toLowerCase()) {
         case 'high':
           return 'red darken-2'
@@ -110,7 +123,7 @@ let mixin = {
       }
     },
     getHistoryTypeColor: (type) => {
-      if (typeof type !== 'string' || type ===  '') return ''
+      if (typeof type !== 'string' || type === '') return ''
       switch (type.toLowerCase()) {
         case 'created':
           return 'teal lighten-2'
@@ -123,7 +136,7 @@ let mixin = {
       }
     },
     getDataSourceIcon: (dataSource) => {
-      if ( typeof dataSource !== 'string' || !dataSource.split(':')[0] ) { return 'mdi-help-circle-outline' }
+      if (typeof dataSource !== 'string' || !dataSource.split(':')[0]) { return 'mdi-help-circle-outline' }
       switch (dataSource.split(':')[0].toLowerCase()) {
         case 'aws':
           return 'mdi-aws'
@@ -135,12 +148,12 @@ let mixin = {
           return 'mdi-github'
         case 'google':
           return 'mdi-google-cloud'
-          default:
+        default:
           return 'mdi-help-circle-outline'
       }
     },
     getDataSourceIconColor: (dataSource) => {
-      if ( typeof dataSource !== 'string' || !dataSource.split(':')[0] ) { return '' }
+      if (typeof dataSource !== 'string' || !dataSource.split(':')[0]) { return '' }
       switch (dataSource.split(':')[0].toLowerCase()) {
         case 'aws':
           return 'orange'
@@ -171,7 +184,7 @@ let mixin = {
       }
     },
     isInProgressDataSourceStatus: (status) => {
-      if ( Number(status) === 3) return true
+      if (Number(status) === 3) return true
       return false
     },
     getDataSourceStatusColor: (status) => {
@@ -203,7 +216,7 @@ let mixin = {
       }
     },
     getFindingStatus: (statusText) => {
-      if (typeof statusText !== 'string' || statusText ===  '') return 0
+      if (typeof statusText !== 'string' || statusText === '') return 0
       switch (statusText.toUpperCase()) {
         case 'ALL':
           return 0
@@ -228,7 +241,7 @@ let mixin = {
       }
     },
     getFindingSettingStatus: (statusText) => {
-      if (typeof statusText !== 'string' || statusText ===  '') return 0
+      if (typeof statusText !== 'string' || statusText === '') return 0
       switch (statusText.toUpperCase()) {
         case 'ACTIVE':
           return 1
@@ -249,7 +262,7 @@ let mixin = {
       }
     },
     getAlertStatus: (statusText) => {
-      if (typeof statusText !== 'string' || statusText ===  '') return 0
+      if (typeof statusText !== 'string' || statusText === '') return 0
       switch (statusText.toUpperCase()) {
         case 'ACTIVE':
           return 1
@@ -274,25 +287,25 @@ let mixin = {
       }
     },
     cutLongText: (str, cutNum) => {
-      if (typeof str !== 'string' ) return '' 
-      if (str.length < cutNum || cutNum < 1 ) {
+      if (typeof str !== 'string') return ''
+      if (str.length < cutNum || cutNum < 1) {
         return str
       }
       return str.substr(0, cutNum) + ' ...'
     },
     getShortName: (longName) => {
       // colon
-      if ( !longName.split(':').slice(-1)[0] ) { return longName }
+      if (!longName.split(':').slice(-1)[0]) { return longName }
       const endOfColon = longName.split(':').slice(-1)[0]
 
       // slash
-      if ( !endOfColon.split('/') ) { return endOfColon }
+      if (!endOfColon.split('/')) { return endOfColon }
       const slashSplited = endOfColon.split('/')
 
-      if ( slashSplited.length < 2 ) {
-        return slashSplited[slashSplited.length -1]
+      if (slashSplited.length < 2) {
+        return slashSplited[slashSplited.length - 1]
       }
-      return slashSplited[slashSplited.length -2] + '/' + slashSplited[slashSplited.length -1]
+      return slashSplited[slashSplited.length - 2] + '/' + slashSplited[slashSplited.length - 1]
     },
     async listResourceNameForCombobox(event) {
       let input = ''
@@ -305,10 +318,10 @@ let mixin = {
       // console.log(input)
       this.loading = true
       const list = await this.listResourceID('&resource_name=' + input + '&offset=0&limit=10&sort=resource_name&direction=asc')
-      if ( !list.resource_id || list.resource_id.length == 0 ) {
+      if (!list.resource_id || list.resource_id.length == 0) {
         this.resourceNameCombobox = []
         this.loading = false
-        return 
+        return
       }
       let rnList = []
       list.resource_id.forEach(async id => {
@@ -323,7 +336,7 @@ let mixin = {
       return false // others not supported.
     },
     getRouterByResource(resourceName, id) {
-      if (String(resourceName).startsWith('arn:')) return { path: '/aws/activity', query: { aws_id: id, arn: resourceName }}
+      if (String(resourceName).startsWith('arn:')) return { path: '/aws/activity', query: { aws_id: id, arn: resourceName } }
       return {} // others not supported.
     },
     handleProjectTagUpdated(message) {
@@ -333,4 +346,4 @@ let mixin = {
   },
 }
 
-export default mixin 
+export default mixin

--- a/src/view/Dashboard.vue
+++ b/src/view/Dashboard.vue
@@ -6,7 +6,9 @@
         <v-col cols="12">
           <v-toolbar flat color="background">
             <v-toolbar-title class="grey--text text--darken-4 headline">
-              <v-icon x-large class="pr-2" color="indigo darken-2">mdi-thermometer</v-icon>
+              <v-icon x-large class="pr-2" color="indigo darken-2"
+                >mdi-thermometer</v-icon
+              >
               {{ $t(`view.dashboard['Status']`) }}
             </v-toolbar-title>
           </v-toolbar>
@@ -18,7 +20,9 @@
           <status-statistic
             :icon="status.risk.icon"
             :color="status.risk.color"
-            :description="$t(`view.dashboard['`+status.risk.description+`']`)"
+            :description="
+              $t(`view.dashboard['` + status.risk.description + `']`)
+            "
             :detail="status.risk.detail"
             class="mx-2"
           />
@@ -34,9 +38,9 @@
             <mini-statistic
               :icon="factor.icon"
               :title="factor.title"
-              :sub-title="$t(`view.dashboard['`+factor.subTitle+`']`)"
+              :sub-title="$t(`view.dashboard['` + factor.subTitle + `']`)"
               :color="factor.color"
-            class="mb-2"
+              class="mb-2"
             />
           </v-card>
         </v-col>
@@ -47,18 +51,16 @@
         <v-col cols="12">
           <v-toolbar flat color="background">
             <v-toolbar-title class="grey--text text--darken-4 headline">
-              <v-icon x-large class="pr-2" color="indigo darken-2">mdi-shape</v-icon>
+              <v-icon x-large class="pr-2" color="indigo darken-2"
+                >mdi-shape</v-icon
+              >
               {{ $t(`view.dashboard['Category']`) }}
             </v-toolbar-title>
           </v-toolbar>
         </v-col>
       </v-row>
       <v-row class="mx-2">
-        <v-col
-          cols="3"
-          v-for="c in category"
-          :key="c.category"
-        >
+        <v-col cols="3" v-for="c in category" :key="c.category">
           <category-statistic
             :icon="c.icon"
             :category="c.category"
@@ -76,7 +78,9 @@
         <v-col cols="12">
           <v-toolbar flat color="background">
             <v-toolbar-title class="grey--text text--darken-4 headline">
-              <v-icon x-large class="pr-2" color="indigo darken-2">mdi-chart-areaspline</v-icon>
+              <v-icon x-large class="pr-2" color="indigo darken-2"
+                >mdi-chart-areaspline</v-icon
+              >
               {{ $t(`view.dashboard['Chart']`) }}
             </v-toolbar-title>
           </v-toolbar>
@@ -106,53 +110,74 @@
           </v-card>
         </v-col>
       </v-row>
-
     </v-container>
     <v-dialog v-model="settingDialog" max-width="600px">
       <v-card>
         <v-card-title class="headline">
-          <span class="mx-2">{{ $t(`view.dashboard['SETTING TUTORIAL']`) }}</span>
+          <span class="mx-2">{{
+            $t(`view.dashboard['SETTING TUTORIAL']`)
+          }}</span>
         </v-card-title>
         <v-list two-line>
           <v-list-item>
             <v-list-item-content>
               <v-list-item-subtitle>
-                {{ $t(`view.dashboard['1. User invited']`) }}: <span class="headline">{{ status.tutorial.invitedUsers }}</span>
+                {{ $t(`view.dashboard['1. User invited']`) }}:
+                <span class="headline">{{ status.tutorial.invitedUsers }}</span>
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
               <v-list-item-subtitle>
-                {{ $t(`view.dashboard['2. Setting data sources(≒ Store some findings)']`) }}: <span class="headline">{{ status.tutorial.storeFindings }}</span>
+                {{
+                  $t(
+                    `view.dashboard['2. Setting data sources(≒ Store some findings)']`
+                  )
+                }}:
+                <span class="headline">{{
+                  status.tutorial.storeFindings
+                }}</span>
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
               <v-list-item-subtitle>
-                {{ $t(`view.dashboard['3. Setting alert condition']`) }}: <span class="headline">{{ status.tutorial.alertConditions }}</span>
+                {{ $t(`view.dashboard['3. Setting alert condition']`) }}:
+                <span class="headline">{{
+                  status.tutorial.alertConditions
+                }}</span>
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
               <v-list-item-subtitle>
-                {{ $t(`view.dashboard['4. Setting alert rule']`) }}: <span class="headline">{{ status.tutorial.alertRules }}</span>
+                {{ $t(`view.dashboard['4. Setting alert rule']`) }}:
+                <span class="headline">{{ status.tutorial.alertRules }}</span>
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
               <v-list-item-subtitle>
-                {{ $t(`view.dashboard['5. Setting alert notification']`) }}: <span class="headline">{{ status.tutorial.notifications }}</span>
+                {{ $t(`view.dashboard['5. Setting alert notification']`) }}:
+                <span class="headline">{{
+                  status.tutorial.notifications
+                }}</span>
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
         </v-list>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn text outlined color="grey darken-1" @click="settingDialog = false">
+          <v-btn
+            text
+            outlined
+            color="grey darken-1"
+            @click="settingDialog = false"
+          >
             {{ $t(`btn['CANCEL']`) }}
           </v-btn>
         </v-card-actions>
@@ -162,17 +187,17 @@
 </template>
 
 <script>
-import Util from '@/util'
-import mixin from '@/mixin'
-import finding from '@/mixin/api/finding'
-import alert from '@/mixin/api/alert'
-import StatusStatistic from '@/component/widget/statistic/StatusStatistic'
-import MiniStatistic from '@/component/widget/statistic/MiniStatistic'
-import CategoryStatistic from '@/component/widget/statistic/CategoryStatistic'
-import TimeLineChart from '@/component/widget/chart/TimeLineChart'
-import DoughnutChart from '@/component/widget/chart/DoughnutChart'
+import Util from "@/util"
+import mixin from "@/mixin"
+import finding from "@/mixin/api/finding"
+import alert from "@/mixin/api/alert"
+import StatusStatistic from "@/component/widget/statistic/StatusStatistic"
+import MiniStatistic from "@/component/widget/statistic/MiniStatistic"
+import CategoryStatistic from "@/component/widget/statistic/CategoryStatistic"
+import TimeLineChart from "@/component/widget/chart/TimeLineChart"
+import DoughnutChart from "@/component/widget/chart/DoughnutChart"
 export default {
-  name: 'PageDashboard',
+  name: "PageDashboard",
   mixins: [mixin, finding, alert],
   components: {
     StatusStatistic,
@@ -183,39 +208,40 @@ export default {
   },
   data() {
     return {
-      nowUnix:  0,
-      oneMonthAgoUnix:  0,
-      nowDate: '',
-      oneMonthAgoDate:  '',
+      nowUnix: 0,
+      oneMonthAgoUnix: 0,
+      nowDate: "",
+      oneMonthAgoDate: "",
       raw: {
         activeAlert: [],
         highScoreFinding: [],
 
-        settingStep: 5,     // [Total 5 setting steps]
-        invitedUser: [],    // 1. User invited, 
-        storeFinding: 0,    // 2, Setting DataSources ( = Store some Findings),
+        settingStep: 5, // [Total 5 setting steps]
+        invitedUser: [], // 1. User invited,
+        storeFinding: 0, // 2, Setting DataSources ( = Store some Findings),
         alertCondition: [], // 3. Setting Alert Condition,
-        alertRule: [],      // 4. Setting Alert Rule,
-        notification: [],   // 5. Setting Alert Notification
+        alertRule: [], // 4. Setting Alert Rule,
+        notification: [], // 5. Setting Alert Notification
       },
       status: {
-        alert: '-',
-        finding: '-',
-        compSettingRate: '-',
-        imcompSetting: '-',
+        alert: "-",
+        finding: "-",
+        compSettingRate: "-",
+        imcompSetting: "-",
         riskFactor: [],
         risk: {
-          icon: 'mdi-map-marker-question-outline',
-          color: 'grey',
-          description: 'There is nothing to display.',
-          detail: 'Please reload after selecting the project.',
+          icon: "mdi-map-marker-question-outline",
+          color: "grey",
+          description: "There is nothing to display.",
+          detail: "Please reload after selecting the project.",
         },
-        tutorial: {           // [Total 5 setting steps]
-          invitedUsers:    0, // 1. User invited, 
-          storeFindings:   0, // 2, Setting DataSources ( = Store some Findings),
+        tutorial: {
+          // [Total 5 setting steps]
+          invitedUsers: 0, // 1. User invited,
+          storeFindings: 0, // 2, Setting DataSources ( = Store some Findings),
           alertConditions: 0, // 3. Setting Alert Condition,
-          alertRules:      0, // 4. Setting Alert Rule,
-          notifications:   0, // 5. Setting Alert Notification
+          alertRules: 0, // 4. Setting Alert Rule,
+          notifications: 0, // 5. Setting Alert Notification
         },
       },
 
@@ -229,24 +255,24 @@ export default {
             labels: [new Date()],
             datasets: [
               {
-                label: 'Findings',
+                label: "Findings",
                 data: [0],
-                type: 'line',
+                type: "line",
                 lineTension: 0.3,
-              }
-            ]
+              },
+            ],
           },
         },
         alert: {
           data: {
-            labels: ['high', 'medium', 'low'],
+            labels: ["high", "medium", "low"],
             datasets: [
               {
-                label: 'Alerts',
+                label: "Alerts",
                 data: [10, 40, 50],
-                type: 'doughnut',
-              }
-            ]
+                type: "doughnut",
+              },
+            ],
           },
         },
       },
@@ -254,13 +280,19 @@ export default {
     }
   },
   async mounted() {
+    await this.signinUser()
     if (!this.$store.state.project.project_id) {
       return false
     }
     this.nowUnix = Math.floor(new Date() / 1000)
-    this.oneMonthAgoUnix = Math.floor(new Date().setMonth(new Date().getMonth() - 1) / 1000)
-    this.nowDate = Util.formatDate(new Date(this.nowUnix * 1000), 'yyyy-MM-dd')
-    this.oneMonthAgoDate = Util.formatDate(new Date(this.oneMonthAgoUnix * 1000), 'yyyy-MM-dd')
+    this.oneMonthAgoUnix = Math.floor(
+      new Date().setMonth(new Date().getMonth() - 1) / 1000
+    )
+    this.nowDate = Util.formatDate(new Date(this.nowUnix * 1000), "yyyy-MM-dd")
+    this.oneMonthAgoDate = Util.formatDate(
+      new Date(this.oneMonthAgoUnix * 1000),
+      "yyyy-MM-dd"
+    )
 
     await this.setRawData()
     this.setStatus()
@@ -272,46 +304,63 @@ export default {
     async setRawData() {
       await this.setActiveAlert()
       await this.setHighScoreFinding()
-      await this.setUser()              // 1. User invited, 
-      await this.setStoreFinding()      // 2, Setting DataSources ( = Store some Findings),
-      await this.setAlertCondition()    // 3. Setting Alert Condition,
-      await this.setAlertRule()         // 4. Setting Alert Rule,
+      await this.setUser() // 1. User invited,
+      await this.setStoreFinding() // 2, Setting DataSources ( = Store some Findings),
+      await this.setAlertCondition() // 3. Setting Alert Condition,
+      await this.setAlertRule() // 4. Setting Alert Rule,
       await this.setAlertNotification() // 5. Setting Alert Notification
     },
     // alert list
     async setActiveAlert() {
-      const list = await this.listAlert('&status=' + this.getAlertStatus('ACTIVE'))
+      const list = await this.listAlert(
+        "&status=" + this.getAlertStatus("ACTIVE")
+      )
       this.raw.activeAlert = list
     },
     // Findings
     async setHighScoreFinding() {
       // await this.getFindingReport(this.oneMonthAgoDate, this.nowDate, 0.79)
-      const [all, aws, diagnosis, osint, code, google ] = await Promise.all([
-         this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, ''),
-         this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, 'aws:'),
-         this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, 'diagnosis:'),
-         this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, 'osint:'),
-         this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, 'code:'),
-         this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, 'google:'),
+      const [all, aws, diagnosis, osint, code, google] = await Promise.all([
+        this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, ""),
+        this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, "aws:"),
+        this.getFindingCount(
+          this.oneMonthAgoUnix,
+          this.nowUnix,
+          0.8,
+          "diagnosis:"
+        ),
+        this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, "osint:"),
+        this.getFindingCount(this.oneMonthAgoUnix, this.nowUnix, 0.8, "code:"),
+        this.getFindingCount(
+          this.oneMonthAgoUnix,
+          this.nowUnix,
+          0.8,
+          "google:"
+        ),
       ])
-      this.raw.highScoreFinding          = all
-      this.raw.highScoreFindingAWS       = aws
+      this.raw.highScoreFinding = all
+      this.raw.highScoreFindingAWS = aws
       this.raw.highScoreFindingDiagnosis = diagnosis
-      this.raw.highScoreFindingOsint     = osint
-      this.raw.highScoreFindingCode      = code
-      this.raw.highScoreFindingGoogle    = google
+      this.raw.highScoreFindingOsint = osint
+      this.raw.highScoreFindingCode = code
+      this.raw.highScoreFindingGoogle = google
     },
     async setStoreFinding() {
-      const storeFindings= await this.getFindingCount(0, this.nowUnix, 0, '')
+      const storeFindings = await this.getFindingCount(0, this.nowUnix, 0, "")
       this.raw.storeFinding = storeFindings
       this.status.tutorial.storeFindings = storeFindings
     },
     async getFindingCount(fromAt, toAt, fromScore, dataSource) {
-      const searceCondition = '&from_at=' + fromAt
-          + '&to_at=' + toAt
-          + '&from_score=' + fromScore
-          + '&data_source=' + dataSource
-          + '&status=1&offset=0&limit=200'
+      const searceCondition =
+        "&from_at=" +
+        fromAt +
+        "&to_at=" +
+        toAt +
+        "&from_score=" +
+        fromScore +
+        "&data_source=" +
+        dataSource +
+        "&status=1&offset=0&limit=200"
       const count = await this.listFindingCnt(searceCondition)
       return count
     },
@@ -319,12 +368,15 @@ export default {
     // User
     async setUser() {
       this.raw.invitedUser = []
-      const res = await this.$axios.get(
-        '/iam/list-user/?activated=true&project_id=' + this.$store.state.project.project_id
-      ).catch((err) =>  {
-        return Promise.reject(err)
-      })
-      if ( !res.data || !res.data.data || !res.data.data.user_id ) {
+      const res = await this.$axios
+        .get(
+          "/iam/list-user/?activated=true&project_id=" +
+            this.$store.state.project.project_id
+        )
+        .catch((err) => {
+          return Promise.reject(err)
+        })
+      if (!res.data || !res.data.data || !res.data.data.user_id) {
         return
       }
       this.status.tutorial.invitedUsers = res.data.data.user_id.length
@@ -333,16 +385,18 @@ export default {
     // Alert condition
     async setAlertCondition() {
       this.raw.alertCondition = []
-      const alert_condition = await this.listAlertCondition(true).catch((err) =>  {
-        return Promise.reject(err)
-      })
+      const alert_condition = await this.listAlertCondition(true).catch(
+        (err) => {
+          return Promise.reject(err)
+        }
+      )
       this.status.tutorial.alertConditions = alert_condition.length
       this.raw.alertCondition = alert_condition
     },
     // Alert condition
     async setAlertRule() {
       this.raw.alertRule = []
-      const alert_rule = await this.listAlertRule().catch((err) =>  {
+      const alert_rule = await this.listAlertRule().catch((err) => {
         return Promise.reject(err)
       })
       this.status.tutorial.alertRules = alert_rule.length
@@ -351,7 +405,7 @@ export default {
     // Notification
     async setAlertNotification() {
       this.raw.notification = []
-      const notification = await this.listAlertNotification().catch((err) =>  {
+      const notification = await this.listAlertNotification().catch((err) => {
         return Promise.reject(err)
       })
       this.status.tutorial.notifications = notification.length
@@ -361,31 +415,31 @@ export default {
     // -- Status ---------------------------------
     setStatus() {
       this.status.alert = this.raw.activeAlert
-      this.status.finding = this.raw.highScoreFinding,
-      this.setSettingStatus()
+      ;(this.status.finding = this.raw.highScoreFinding),
+        this.setSettingStatus()
 
       this.setTotalStatus()
       this.status.riskFactor = []
       this.status.riskFactor.push({
         title: this.status.alert.length.toString(),
-        subTitle: 'Action required ....',
-        icon: 'mdi-alert',
-        color: 'red darken-3',
-        link: '/alert/alert/',
+        subTitle: "Action required ....",
+        icon: "mdi-alert",
+        color: "red darken-3",
+        link: "/alert/alert/",
       })
       this.status.riskFactor.push({
         title: String(this.status.finding),
-        subTitle: 'High score findings ',
-        icon: 'mdi-file-find-outline',
-        color: 'blue darken-1',
-        link: '/finding/finding/?from_score=0.8',
+        subTitle: "High score findings ",
+        icon: "mdi-file-find-outline",
+        color: "blue darken-1",
+        link: "/finding/finding/?from_score=0.8",
       })
       this.status.riskFactor.push({
         title: this.status.compSettingRate,
-        subTitle: 'Settings coverage...',
-        icon: 'mdi-cog',
-        color: 'grey darken-2',
-        link: 'settingDialog',
+        subTitle: "Settings coverage...",
+        icon: "mdi-cog",
+        color: "grey darken-2",
+        link: "settingDialog",
       })
     },
     // Setting Status
@@ -407,7 +461,8 @@ export default {
         completed++
       }
       this.status.imcompSetting = this.raw.settingStep - completed
-      this.status.compSettingRate = ((completed / this.raw.settingStep) * 100 ).toString() + '%'
+      this.status.compSettingRate =
+        ((completed / this.raw.settingStep) * 100).toString() + "%"
     },
     // Total Status
     setTotalStatus() {
@@ -419,30 +474,35 @@ export default {
       if (this.status.finding && this.status.finding.length) {
         totalRisk += Number(this.status.finding.length)
       }
-      this.status.risk.detail = 
-        '  Active alerts: ' + this.status.alert.length +
-        ', High score findings: ' + this.status.finding +
-        ', Imcompleted settings: ' + this.status.imcompSetting + ' / ' + this.raw.settingStep
-      if ( this.status.imcompSetting === this.raw.settingStep ) {
-        this.status.risk.icon = 'mdi-message-settings'
-        this.status.risk.color = 'cyan'
-        this.status.risk.description = 'You need to configure some settings 🔜'
-      } else if ( totalRisk === 0 ) {
-        this.status.risk.icon = 'mdi-check-circle-outline'
-        this.status.risk.color = 'green'
-        this.status.risk.description = 'No problem. 👌'
-      } else if ( 0 < totalRisk && totalRisk <= 3 ) {
-        this.status.risk.icon = 'mdi-weather-cloudy'
-        this.status.risk.color = 'grey darken-1'
-        this.status.risk.description = 'Need to check a few things. 👀'
-      } else if ( 3 < totalRisk && totalRisk <= 10 ) {
-        this.status.risk.icon = 'mdi-weather-pouring'
-        this.status.risk.color = 'lime darken-3'
-        this.status.risk.description = 'There are some problems... 😥'
+      this.status.risk.detail =
+        "  Active alerts: " +
+        this.status.alert.length +
+        ", High score findings: " +
+        this.status.finding +
+        ", Imcompleted settings: " +
+        this.status.imcompSetting +
+        " / " +
+        this.raw.settingStep
+      if (this.status.imcompSetting === this.raw.settingStep) {
+        this.status.risk.icon = "mdi-message-settings"
+        this.status.risk.color = "cyan"
+        this.status.risk.description = "You need to configure some settings 🔜"
+      } else if (totalRisk === 0) {
+        this.status.risk.icon = "mdi-check-circle-outline"
+        this.status.risk.color = "green"
+        this.status.risk.description = "No problem. 👌"
+      } else if (0 < totalRisk && totalRisk <= 3) {
+        this.status.risk.icon = "mdi-weather-cloudy"
+        this.status.risk.color = "grey darken-1"
+        this.status.risk.description = "Need to check a few things. 👀"
+      } else if (3 < totalRisk && totalRisk <= 10) {
+        this.status.risk.icon = "mdi-weather-pouring"
+        this.status.risk.color = "lime darken-3"
+        this.status.risk.description = "There are some problems... 😥"
       } else {
-        this.status.risk.icon = 'mdi-weather-lightning'
-        this.status.risk.color = 'red darken-2'
-        this.status.risk.description = 'We have a lot of problems... 🙀'
+        this.status.risk.icon = "mdi-weather-lightning"
+        this.status.risk.color = "red darken-2"
+        this.status.risk.description = "We have a lot of problems... 🙀"
       }
     },
 
@@ -450,67 +510,67 @@ export default {
     setCategory() {
       this.category = []
       this.category.push({
-        category: 'User',
+        category: "User",
         title: this.raw.invitedUser.length.toString(),
-        subTitle: 'Project members',
-        icon: 'mdi-account-multiple',
-        color: 'cyan lighten-2',
+        subTitle: "Project members",
+        icon: "mdi-account-multiple",
+        color: "cyan lighten-2",
         dark: false,
-        link: '/iam/user/',
+        link: "/iam/user/",
       })
       this.category.push({
-        category: 'AWS',
+        category: "AWS",
         title: String(this.raw.highScoreFindingAWS),
-        subTitle: 'High score findings',
-        icon: 'mdi-aws',
-        color: 'orange darken-1',
+        subTitle: "High score findings",
+        icon: "mdi-aws",
+        color: "orange darken-1",
         dark: true,
-        link: '/finding/finding/?from_score=0.8&data_source=aws:',
+        link: "/finding/finding/?from_score=0.8&data_source=aws:",
       })
       this.category.push({
-        category: 'Diagnosis',
+        category: "Diagnosis",
         title: String(this.raw.highScoreFindingDiagnosis),
-        subTitle: 'High score findings',
-        icon: 'mdi-bug-check-outline',
-        color: 'indigo darken-1',
+        subTitle: "High score findings",
+        icon: "mdi-bug-check-outline",
+        color: "indigo darken-1",
         dark: true,
-        link: '/finding/finding/?from_score=0.8&data_source=diagnosis:',
+        link: "/finding/finding/?from_score=0.8&data_source=diagnosis:",
       })
       this.category.push({
-        category: 'OSINT',
+        category: "OSINT",
         title: String(this.raw.highScoreFindingOsint),
-        subTitle: 'High score findings',
-        icon: 'http',
-        color: 'green darken-1',
+        subTitle: "High score findings",
+        icon: "http",
+        color: "green darken-1",
         dark: true,
-        link: '/finding/finding/?from_score=0.8&data_source=osint:',
+        link: "/finding/finding/?from_score=0.8&data_source=osint:",
       })
       this.category.push({
-        category: 'Code',
+        category: "Code",
         title: String(this.raw.highScoreFindingCode),
-        subTitle: 'High score findings',
-        icon: 'mdi-github',
-        color: 'black',
+        subTitle: "High score findings",
+        icon: "mdi-github",
+        color: "black",
         dark: true,
-        link: '/finding/finding/?from_score=0.8&data_source=code:',
+        link: "/finding/finding/?from_score=0.8&data_source=code:",
       })
       this.category.push({
-        category: 'Google',
+        category: "Google",
         title: String(this.raw.highScoreFindingGoogle),
-        subTitle: 'High score findings',
-        icon: 'mdi-google',
-        color: 'light-blue darken-1',
+        subTitle: "High score findings",
+        icon: "mdi-google",
+        color: "light-blue darken-1",
         dark: true,
-        link: '/finding/finding/?from_score=0.8&data_source=google:',
+        link: "/finding/finding/?from_score=0.8&data_source=google:",
       })
       this.category.push({
-        category: 'Azure',
-        title: '-',
-        subTitle: 'Not yet supported...',
-        icon: 'mdi-microsoft-azure',
-        color: 'blue darken-1',
+        category: "Azure",
+        title: "-",
+        subTitle: "Not yet supported...",
+        icon: "mdi-microsoft-azure",
+        color: "blue darken-1",
         dark: true,
-        link: '/finding/finding/?from_score=0.8&data_source=azure:',
+        link: "/finding/finding/?from_score=0.8&data_source=azure:",
       })
     },
 
@@ -523,15 +583,34 @@ export default {
     async setFindingChart() {
       const now = new Date()
       for (let day = 7; day >= 0; day--) {
-        const from = new Date(now.getFullYear(), now.getMonth(), now.getDate() -day, 0, 0, 0)
-        const to = new Date(now.getFullYear(), now.getMonth(), now.getDate() -day +1, 0, 0, 0)
+        const from = new Date(
+          now.getFullYear(),
+          now.getMonth(),
+          now.getDate() - day,
+          0,
+          0,
+          0
+        )
+        const to = new Date(
+          now.getFullYear(),
+          now.getMonth(),
+          now.getDate() - day + 1,
+          0,
+          0,
+          0
+        )
         await this.setFindingChartByDayNumber(from, to)
       }
     },
-    async setFindingChartByDayNumber(from, to){
+    async setFindingChartByDayNumber(from, to) {
       const fromUnix = Math.floor(from / 1000)
       const toUnix = Math.floor(to / 1000)
-      const findingCount = await this.getFindingCount(fromUnix, toUnix-1, 0, '')
+      const findingCount = await this.getFindingCount(
+        fromUnix,
+        toUnix - 1,
+        0,
+        ""
+      )
       this.chart.finding.data.labels.push(from)
       this.chart.finding.data.datasets[0].data.push(findingCount)
     },
@@ -539,31 +618,31 @@ export default {
     //   return dt.getMonth()+1 + '/' + dt.getDate() // `getMonth()` will return 0~11, because need +1 month for display label
     // }
     setAlertChart() {
-      this.chart.alert.data.labels = [ 'high', 'medium', 'low']
-      let highCnt =0
+      this.chart.alert.data.labels = ["high", "medium", "low"]
+      let highCnt = 0
       let mediumCnt = 0
       let lowCnt = 0
-      this.raw.activeAlert.forEach( async alert => {
+      this.raw.activeAlert.forEach(async (alert) => {
         switch (alert.severity) {
-          case 'high':
+          case "high":
             highCnt++
             break
-          case 'medium': 
+          case "medium":
             mediumCnt++
             break
-          case 'low':
+          case "low":
             lowCnt++
             break
           default:
-            console.log('Unknown serverity: ' + alert.severity)
+            console.log("Unknown serverity: " + alert.severity)
         }
       })
-      this.chart.alert.data.datasets[0].data = [ highCnt, mediumCnt, lowCnt ]
+      this.chart.alert.data.datasets[0].data = [highCnt, mediumCnt, lowCnt]
     },
 
     // handler
     handleClickFactor(link) {
-      if (link === 'settingDialog') {
+      if (link === "settingDialog") {
         this.handleSettingSteps()
         return
       }
@@ -571,7 +650,7 @@ export default {
     },
     handleSettingSteps() {
       this.settingDialog = true
-    }
+    },
   },
 }
 </script>

--- a/src/view/Home.vue
+++ b/src/view/Home.vue
@@ -1,24 +1,17 @@
 <template><div /></template>
 <script>
-import store from '@/store'
-import mixin from '@/mixin'
+import mixin from "@/mixin"
 
 export default {
-  name: 'Home',
-  mounted() { this.signinUser() },
+  name: "Home",
+  mounted() {
+    this.redirectDashBoard()
+  },
   mixins: [mixin],
   methods: {
-    async signinUser() {
-      store.commit('storeUser', {})
-      const userID = await this.signin().catch((err) =>  {
-        return Promise.reject(err)
-      })
-      const user = await this.$axios.get('/iam/get-user?user_id=' + userID).catch((err) => {
-        return Promise.reject(err)
-      })
-      store.commit('storeUser', user.data.data.user)
-      this.$router.push('/dashboard')
-    }
+    async redirectDashBoard() {
+      this.$router.push("/dashboard")
+    },
   },
 }
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3338,11 +3338,6 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
-
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
@@ -4006,13 +4001,6 @@ faye-websocket@~0.11.1:
   integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   dependencies:
     websocket-driver ">=0.5.1"
-
-fibers@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fibers/-/fibers-5.0.0.tgz#3a60e0695b3ee5f6db94e62726716fa7a59acc41"
-  integrity sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==
-  dependencies:
-    detect-libc "^1.0.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"


### PR DESCRIPTION
### 事象
プロジェクト切り替えをしている時に、うまく切り替えができずに、プロジェクト一覧がくるくる状態のままになりリストが表示されないときがある。

### 再現方法
プロジェクトAを選択しているときに別タブでプロジェクトBを選択。
前のタブに戻ってプロジェクトを一覧を開こうとするとリストが表示されない。

### 原因
LocalStorageの情報が別のところで更新されると、うまくデータがひっぱってこれない事象が起きていました。

### 対応
毎回サインイン処理をしてからユーザデータを取得する形に変えます。
（プロジェクト一覧の表示はそのユーザが権限を持ってるリストを表示するため、前提としてユーザIDがないといけない）