### PR TITLE
fix alert finding

### DIFF
--- a/src/mixin/api/aws.js
+++ b/src/mixin/api/aws.js
@@ -6,26 +6,26 @@ const aws = {
     async listAWSAPI() {
       const res = await this.$axios.get(
         '/aws/list-aws/?project_id=' + this.$store.state.project.project_id
-      ).catch((err) =>  {
+      ).catch((err) => {
         return Promise.reject(err)
       })
-      if ( !res.data.data.aws ) {
+      if (!res.data.data.aws) {
         return []
       }
-      return res.data.data.aws  
+      return res.data.data.aws
     },
     async deleteAWSAPI(awsID) {
       const param = {
         project_id: this.$store.state.project.project_id,
         aws_id: awsID,
       }
-      const res = await this.$axios.post('/aws/delete-aws/', param).catch((err) =>  {
+      const res = await this.$axios.post('/aws/delete-aws/', param).catch((err) => {
         return Promise.reject(err)
       })
       return res
     },
     async putAWSAPI(name, aws_account_id) {
-      const param = { 
+      const param = {
         project_id: this.$store.state.project.project_id,
         aws: {
           project_id: this.$store.state.project.project_id,
@@ -33,7 +33,7 @@ const aws = {
           aws_account_id: aws_account_id,
         },
       }
-      const res = await this.$axios.post('/aws/put-aws/', param).catch((err) =>  {
+      const res = await this.$axios.post('/aws/put-aws/', param).catch((err) => {
         return Promise.reject(err)
       })
       return res
@@ -42,17 +42,17 @@ const aws = {
     async listAWSDataSourceAPI(aws_id, data_source) {
       const res = await this.$axios.get(
         '/aws/list-datasource/'
-            + '?project_id=' + this.$store.state.project.project_id 
-            + '&aws_id=' + aws_id
-            + '&data_source=' + data_source
+        + '?project_id=' + this.$store.state.project.project_id
+        + '&aws_id=' + aws_id
+        + '&data_source=' + data_source
 
-      ).catch((err) =>  {
+      ).catch((err) => {
         return Promise.reject(err)
       })
-      if ( !res.data.data.data_source ) {
+      if (!res.data.data.data_source) {
         return []
       }
-      return res.data.data.data_source  
+      return res.data.data.data_source
     },
     async detachAWSDataSourceAPI(aws_id, aws_data_source_id) {
       const param = {
@@ -60,13 +60,13 @@ const aws = {
         aws_id: aws_id,
         aws_data_source_id: aws_data_source_id
       }
-      const res = await this.$axios.post('/aws/detach-datasource/', param).catch((err) =>  {
+      const res = await this.$axios.post('/aws/detach-datasource/', param).catch((err) => {
         return Promise.reject(err)
       })
       return res
     },
     async attachAWSDataSourceAPI(param) {
-      const res = await this.$axios.post('/aws/attach-datasource/', param).catch((err) =>  {
+      const res = await this.$axios.post('/aws/attach-datasource/', param).catch((err) => {
         return Promise.reject(err)
       })
       return res
@@ -77,8 +77,9 @@ const aws = {
         project_id: this.$store.state.project.project_id,
         aws_id: aws_id,
         aws_data_source_id: aws_data_source_id,
+        scan_only: false, // optional
       }
-      const res = await this.$axios.post('/aws/invoke-scan/', param).catch((err) =>  {
+      const res = await this.$axios.post('/aws/invoke-scan/', param).catch((err) => {
         return Promise.reject(err)
       })
       return res
@@ -87,13 +88,13 @@ const aws = {
     async describeArnAPI(arn) {
       const res = await this.$axios.get(
         '/aws/describe-arn/?project_id=' + this.$store.state.project.project_id + '&arn=' + arn
-      ).catch((err) =>  {
+      ).catch((err) => {
         return Promise.reject(err)
       })
-      if ( !res.data.data.arn ) {
+      if (!res.data.data.arn) {
         return []
       }
-      return res.data.data.arn  
+      return res.data.data.arn
     },
     async listCloudTrailAPI(
       aws_id,
@@ -105,18 +106,18 @@ const aws = {
       next_token,
     ) {
       const res = await this.$axios.get('/aws/list-cloudtrail/'
-          + '?project_id=' + this.$store.state.project.project_id
-          + '&aws_id=' + aws_id
-          + '&region=' + region
-          + '&start_time=' + start_time
-          + '&end_time=' + end_time
-          + '&attribute_key=' + Number(attr_key)
-          + '&attribute_value=' + attr_value
-          + '&next_token=' + encodeURIComponent(next_token)
-      ).catch((err) =>  {
+        + '?project_id=' + this.$store.state.project.project_id
+        + '&aws_id=' + aws_id
+        + '&region=' + region
+        + '&start_time=' + start_time
+        + '&end_time=' + end_time
+        + '&attribute_key=' + Number(attr_key)
+        + '&attribute_value=' + attr_value
+        + '&next_token=' + encodeURIComponent(next_token)
+      ).catch((err) => {
         return Promise.reject(err)
       })
-      if ( !res.data.data ) {
+      if (!res.data.data) {
         return {}
       }
       return res.data.data
@@ -131,18 +132,18 @@ const aws = {
       starting_token, // like: next_token
     ) {
       const res = await this.$axios.get('/aws/list-config-history/'
-          + '?project_id=' + this.$store.state.project.project_id
-          + '&aws_id=' + aws_id
-          + '&region=' + region
-          + '&resource_type=' + resource_type
-          + '&resource_id=' + resource_id
-          + '&earlier_time=' + earlier_time
-          + '&later_time=' + later_time
-          + '&starting_token=' + encodeURIComponent(starting_token)
-      ).catch((err) =>  {
+        + '?project_id=' + this.$store.state.project.project_id
+        + '&aws_id=' + aws_id
+        + '&region=' + region
+        + '&resource_type=' + resource_type
+        + '&resource_id=' + resource_id
+        + '&earlier_time=' + earlier_time
+        + '&later_time=' + later_time
+        + '&starting_token=' + encodeURIComponent(starting_token)
+      ).catch((err) => {
         return Promise.reject(err)
       })
-      if ( !res.data.data ) {
+      if (!res.data.data) {
         return {}
       }
       return res.data.data
@@ -150,4 +151,4 @@ const aws = {
   },
 }
 
-export default aws 
+export default aws

--- a/src/view/alert/Alert.vue
+++ b/src/view/alert/Alert.vue
@@ -324,6 +324,7 @@ export default {
       alertModel: {},
       alertHistoryModel: [],
       alertResource: [],
+      findingMaxCount: 5,
       table: {
         selected: [],
         search: "",
@@ -440,11 +441,11 @@ export default {
       })
     },
     formatFindingIDs(ids) {
-      if (ids.length <= 5) {
+      if (ids.length <= this.findingMaxCount) {
         return ids
       }
       let formated = []
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < this.findingMaxCount; i++) {
         formated.push(ids[i])
       }
       formated.push("...")
@@ -454,9 +455,12 @@ export default {
     // alert finding list
     async getRelAlertFinding() {
       this.clearFinding()
-      const rel_alert_finding = await this.listRelAlertFinding(
+      let rel_alert_finding = await this.listRelAlertFinding(
         this.alertModel.alert_id
       )
+      if (rel_alert_finding.length > this.findingMaxCount) {
+        rel_alert_finding = rel_alert_finding.slice(0, this.findingMaxCount)
+      }
       rel_alert_finding.forEach(async (finding) => {
         const f = await this.getFinding(finding.finding_id)
         this.alertResource.push(f.resource_name)


### PR DESCRIPTION
アラート履歴表示の際に、大量のFindingが紐付いている場合にAPIリクエストが大量に発生しTimeoutになる問題がありました。
表示上も件数の上限があるので、裏側もそれにあわせて必要最小限のAPIリクエストにするよう調整します