### PR TITLE
fix: json viewer style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test:
 	yarn lint
 
 .PHONY: run
-run: clean test
+run: clean install test
 	yarn serve
 
 .PHONY: clean

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -476,12 +476,10 @@
                 />
               </v-list-item-subtitle>
               <v-card dark color="grey darken-3" class="ma-4">
-                <v-card-text
-                  class="title font-weight-bold"
-                >
+                <v-card-text class="title font-weight-bold">
                   <json-viewer
                     :value="parseFindingData(findingModel.data)"
-                    :expand-depth=5
+                    :expand-depth="5"
                     preview-mode
                     theme="finding-json-theme"
                   ></json-viewer>
@@ -722,7 +720,7 @@ import Util from "@/util"
 import finding from "@/mixin/api/finding"
 import BottomSnackBar from "@/component/widget/snackbar/BottomSnackBar"
 import ClipBoard from "@/component/widget/clipboard/ClipBoard.vue"
-import JsonViewer from 'vue-json-viewer';
+import JsonViewer from "vue-json-viewer"
 export default {
   mixins: [mixin, finding],
   components: {
@@ -1306,67 +1304,88 @@ export default {
         this.handleSearch()
       }
     },
-    parseFindingData (v) {
-    if (!v) {
+    parseFindingData(v) {
+      if (!v) {
         return {}
       }
       return JSON.parse(v)
-    }
+    },
   },
 }
 </script>
 
 <style lang="scss">
 .finding-json-theme {
-    background: #424242;
-    white-space: nowrap;
+  background: #424242;
+  white-space: nowrap;
+  color: #eee;
+  font-size: 18px;
+
+  .jv-ellipsis {
     color: #eee;
-    font-size: 14px;
-    font-family: Consolas, Menlo, Courier, monospace;
-  
-    .jv-ellipsis {
+    background-color: #424242;
+    display: inline-block;
+    line-height: 0.9;
+    font-size: 0.9em;
+    padding: 0px 4px 2px 4px;
+    border-radius: 3px;
+    vertical-align: 2px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .jv-button {
+    color: #49b3ff;
+  }
+  .jv-key {
+    color: rgb(181, 216, 55);
+  }
+  .jv-link {
+    color: #068cca;
+  }
+  .jv-item {
+    &.jv-array {
       color: #eee;
-      background-color: #424242;
-      display: inline-block;
-      line-height: 0.9;
-      font-size: 0.9em;
-      padding: 0px 4px 2px 4px;
-      border-radius: 3px;
-      vertical-align: 2px;
-      cursor: pointer;
-      user-select: none;
     }
-    .jv-button { color: #49b3ff }
-    .jv-key { color: #eee }
-    .jv-link {color: #068cca}
-    .jv-item {
-      &.jv-array { color: #eee }
-      &.jv-boolean { color: #B3E5FC }
-      &.jv-function { color: #068cca }
-      &.jv-number { color: #42b983 }
-      &.jv-number-float { color: #42b983 }
-      &.jv-number-integer { color: #42b983 }
-      &.jv-object { color: #eee }
-      &.jv-undefined { color: #e08331 }
-      &.jv-string {
-        color: #eee;
-        word-break: break-word;
-        white-space: normal;
+    &.jv-boolean {
+      color: #b3e5fc;
+    }
+    &.jv-function {
+      color: #068cca;
+    }
+    &.jv-number {
+      color: #42b983;
+    }
+    &.jv-number-float {
+      color: #42b983;
+    }
+    &.jv-number-integer {
+      color: #42b983;
+    }
+    &.jv-object {
+      color: #eee;
+    }
+    &.jv-undefined {
+      color: #e08331;
+    }
+    &.jv-string {
+      color: #eee;
+      word-break: break-word;
+      white-space: normal;
+    }
+  }
+  .jv-code {
+    padding: 1px;
+    .jv-toggle {
+      &:before {
+        padding: 0px 2px;
+        border-radius: 2px;
       }
-    }
-    .jv-code {
-      .jv-toggle {
+      &:hover {
         &:before {
-          padding: 0px 2px;
-          border-radius: 2px;
-        }
-        &:hover {
-          &:before {
-            background: #eee;
-          }
+          background: #eee;
         }
       }
     }
   }
-
+}
 </style>


### PR DESCRIPTION
JSON部分のスタイルを少しいじります
- FontFamilyは既存のものを使います
- フォントサイズをあげます
- JSONのキー部分がStringの白と同じなので色分けして見やすくします
- 余白が20pxとかなりとってるので縮小します
- その他VueのLinter関連で記述の体裁を整える修正が入ってます