### PR TITLE
fix: too long text

### DIFF
--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -626,9 +626,7 @@
               <v-icon>mdi-image-text</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
-              <v-list-item-title
-                v-text="findingModel.description"
-              ></v-list-item-title>
+              <v-list-item v-text="findingModel.description"></v-list-item>
               <v-list-item-subtitle>{{
                 $t(`item['Description']`)
               }}</v-list-item-subtitle>
@@ -820,9 +818,10 @@
                   ></v-list-item-avatar
                 >
                 <v-list-item-content>
-                  <v-list-item-title
+                  <v-list-item
+                    class="pa-0 ma-0"
                     v-text="recommendModel.risk"
-                  ></v-list-item-title>
+                  ></v-list-item>
                   <v-list-item-subtitle>{{
                     $t(`item['Risk']`)
                   }}</v-list-item-subtitle>
@@ -838,9 +837,10 @@
                   ><v-icon>mdi-comment-check</v-icon></v-list-item-avatar
                 >
                 <v-list-item-content>
-                  <v-list-item-title
+                  <v-list-item
+                    class="pa-0 ma-0"
                     v-text="recommendModel.recommendation"
-                  ></v-list-item-title>
+                  ></v-list-item>
                   <v-list-item-subtitle>{{
                     $t(`item['Recommendation']`)
                   }}</v-list-item-subtitle>


### PR DESCRIPTION
Finding画面の以下の項目については長文で `text-overflow: ellipsis;` スタイルがあたってしまい、末尾が「...」で省略されてしまっていたため、省略されないようにスタイル修正。
- Description
- Risk
- Recommendation