### PR TITLE
fix: recommend text style

### DIFF
--- a/src/component/text/AutoLink.vue
+++ b/src/component/text/AutoLink.vue
@@ -1,0 +1,34 @@
+<script>
+export default {
+  name: 'AutoLink',
+  props: {
+    text: {
+      type: String,
+      default: null,
+    },
+  },
+  render: function (createElement) {
+    var a = this.text.split(/(https?:\/\/([\w!?/+-_~=;.,*&@#$%()']|\[\])+)/i)
+    var vnodes = a.map(function (x, i) {
+      if (i % 2) {
+        return createElement(
+          'a',
+          { attrs: { href: x, target: '_blank', rel: 'noopener' } },
+          x
+        )
+      } else if (!x) {
+        return this._v('')
+      } else {
+        return this._v(x)
+      }
+    }, this)
+    return createElement('span', { attrs: { class: 'auto-link' } }, vnodes)
+  },
+}
+</script>
+
+<style scoped>
+.auto-link {
+  white-space: pre-line;
+}
+</style>

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -122,6 +122,10 @@ const isEmptyString = (str) => {
   return !str || str.length === 0 || /^\s*$/.test(str) || str === 'null'
 }
 
+const isString = (obj) => {
+  return typeof obj === 'string' || obj instanceof String
+}
+
 const isNumber = (value) => {
   return !isNaN(value)
 }
@@ -138,4 +142,5 @@ export default {
   generateVerificationCode,
   isEmptyString,
   isNumber,
+  isString,
 }

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -794,9 +794,11 @@
             </v-col>
             <v-col cols="6">
               <v-list-item>
-                <v-list-item-avatar
-                  ><v-icon>mdi-tag-multiple</v-icon></v-list-item-avatar
-                >
+                <v-list-item-avatar>
+                  <v-icon
+                    v-text="getDataSourceIcon(recommendModel.data_source)"
+                    :color="getDataSourceIconColor(recommendModel.data_source)"
+                /></v-list-item-avatar>
                 <v-list-item-content>
                   <v-list-item-title
                     v-text="recommendModel.data_source"
@@ -813,15 +815,14 @@
             <v-col cols="12">
               <v-list-item>
                 <v-list-item-avatar
-                  ><v-icon
+                  ><v-icon color="yellow darken-3"
                     >mdi-comment-alert-outline</v-icon
                   ></v-list-item-avatar
                 >
                 <v-list-item-content>
-                  <v-list-item
-                    class="pa-0 ma-0"
-                    v-text="recommendModel.risk"
-                  ></v-list-item>
+                  <v-list-item class="pa-0 ma-0">
+                    <auto-link :text="recommendModel.risk" />
+                  </v-list-item>
                   <v-list-item-subtitle>{{
                     $t(`item['Risk']`)
                   }}</v-list-item-subtitle>
@@ -834,13 +835,14 @@
             <v-col cols="12">
               <v-list-item>
                 <v-list-item-avatar
-                  ><v-icon>mdi-comment-check</v-icon></v-list-item-avatar
+                  ><v-icon color="purple darken-2"
+                    >mdi-run</v-icon
+                  ></v-list-item-avatar
                 >
                 <v-list-item-content>
-                  <v-list-item
-                    class="pa-0 ma-0"
-                    v-text="recommendModel.recommendation"
-                  ></v-list-item>
+                  <v-list-item class="pa-0 ma-0">
+                    <auto-link :text="recommendModel.recommendation" />
+                  </v-list-item>
                   <v-list-item-subtitle>{{
                     $t(`item['Recommendation']`)
                   }}</v-list-item-subtitle>
@@ -873,14 +875,16 @@ import mixin from '@/mixin'
 import Util from '@/util'
 import finding from '@/mixin/api/finding'
 import BottomSnackBar from '@/component/widget/snackbar/BottomSnackBar'
-import ClipBoard from '@/component/widget/clipboard/ClipBoard.vue'
+import ClipBoard from '@/component/widget/clipboard/ClipBoard'
 import JsonViewer from 'vue-json-viewer'
+import AutoLink from '@/component/text/AutoLink'
 export default {
   mixins: [mixin, finding],
   components: {
     BottomSnackBar,
     ClipBoard,
     JsonViewer,
+    AutoLink,
   },
   data() {
     return {


### PR DESCRIPTION
レコメンドのコンテンツのスタイル関連を修正
- URLリンクがあればそれを自動でaタグに変換
- 改行を含む場合はCSSで改行折返しを設定
- 複数行のコンテンツでも文字が途中で切られないように修正
- データソースアイコンの動的スタイル変更