### PR TITLE
add: ResourceManager for external API request

### DIFF
--- a/src/axios/index.js
+++ b/src/axios/index.js
@@ -1,20 +1,39 @@
 import Axios from 'axios'
 import router from '../router'
 
+// ResourceManager Config
+const MAX_REQUESTS_COUNT = 5
+const INTERVAL_MS = 10
+let PENDING_REQUESTS = 0
+
 const axios = Axios.create({
   baseURL: '/api/v1',
   timeout: 10000,
 })
 axios.interceptors.request.use(
   (config) => {
-    return config
+    return new Promise((resolve) => {
+      let interval = setInterval(() => {
+        if (PENDING_REQUESTS < MAX_REQUESTS_COUNT) {
+          PENDING_REQUESTS++
+          clearInterval(interval)
+          resolve(config)
+        }
+      }, INTERVAL_MS)
+    })
   },
-  (error) => Promise.reject(error)
+  (error) => {
+    Promise.reject(error)
+  }
 )
 
 axios.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1)
+    return Promise.resolve(response)
+  },
   (error) => {
+    PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1)
     if (error.code && error.code === 'ECONNABORTED') {
       // timeout
       console.log(error)
@@ -40,11 +59,6 @@ axios.interceptors.response.use(
         path: '/403',
         query: { url: router.currentRoute.fullPath },
       })
-      // } else if (status === 404) {
-      //   console.log('404 Not found')
-      //   router.push({path: '/404', query: { url: router.currentRoute.fullPath }})
-      // // } else if (status >= 500 ) {
-      //   router.push({path: '/500', query: { url: router.currentRoute.fullPath }})
     }
     return Promise.reject(error)
   }


### PR DESCRIPTION
外部APIリクエストの大量発生をコントロールすべく、 `ResourceManager` の仕組みを導入します。
これはGoogleChromeのブラウザ仕様（一度のAPIリクエストは最大6件、かつキューにたまったリクエストがメモリを逼迫するとエラーが発生する）の問題への恒久対応です
https://github.com/ca-risken/internal-community/issues/149

### `ResourceManager`
- 同時リクエストを最大5件までに調整します（外部APIリクエスト時にインターセプトしてコントロール）
- 5件以上のリクエストがある場合は0.01秒のインターバルを挟んでからリクエスト
- リクエスト成功または失敗時にペンディングされたリクエストを開始します（APIレスポンス処理をインターセプト）
