### PR TITLE
add: datadog RUM setting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+codebuild
+dist
+hack
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM node:lts-alpine as builder
 WORKDIR /app
-COPY package*.json yarn.lock *.config.js ./
+COPY ./ ./
 RUN yarn install
-COPY src ./src
-COPY public ./public
-RUN yarn run build
+RUN yarn run build-prd
 
 FROM nginx:stable-alpine as production-stage
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/codebuild/multi-arch/buildspec-image.yml
+++ b/codebuild/multi-arch/buildspec-image.yml
@@ -4,10 +4,10 @@ env:
   variables:
     IMAGE_PREFIX: "risken-gateway"
   parameter-store:
-    GITHUB_USER: "/build/GITHUB_USER"
-    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
     DOCKER_USER: "/build/DOCKER_USER"
     DOCKER_TOKEN: "/build/DOCKER_TOKEN"
+    VUE_APP_RUM_ID: "/build/datadog/VUE_APP_RUM_ID"
+    VUE_APP_RUM_TOKEN: "/build/datadog/VUE_APP_RUM_TOKEN"
 
 phases:
   install:
@@ -36,7 +36,10 @@ phases:
   build:
     commands:
       - echo Build web started on `date`
-      - echo Pushing the Docker images...
+      - echo "VUE_APP_RUM_ID=${VUE_APP_RUM_ID}" > env.prd
+      - echo "VUE_APP_RUM_TOKEN=${VUE_APP_RUM_TOKEN}" >> env.prd
+
+      - echo Building the Docker images...
       - make build-ci -j BUILD_OPT="${BUILD_OPT}" IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG=${TAG} IMAGE_REGISTRY=${REGISTRY}
 
   post_build:

--- a/codebuild/release/buildspec-image.yml
+++ b/codebuild/release/buildspec-image.yml
@@ -5,16 +5,8 @@ env:
     PRIVATE_IMAGE_PREFIX: 'risken-gateway'
     PUBLIC_REGISTRY: 'public.ecr.aws/risken'
     PUBLIC_IMAGE_PREFIX: 'gateway'
-  parameter-store:
-    GITHUB_USER: '/build/GITHUB_USER'
-    GITHUB_TOKEN: '/build/GITHUB_TOKEN'
 
 phases:
-  install:
-    commands:
-      - echo "machine github.com" > ~/.netrc
-      - echo "login ${GITHUB_USER}" >> ~/.netrc
-      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
   pre_build:
     commands:
       - echo Setting environment variables

--- a/hack/docker-build.sh
+++ b/hack/docker-build.sh
@@ -5,4 +5,4 @@ fi
 if [ "${IMAGE_PREFIX}" = "" ]; then
   IMAGE_PREFIX=default_prefix
 fi
-docker build ${BUILD_OPT} --build-arg GITHUB_USER=${GITHUB_USER} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t ${IMAGE_PREFIX}/${TARGET}:${IMAGE_TAG} .
+docker build ${BUILD_OPT} -t ${IMAGE_PREFIX}/${TARGET}:${IMAGE_TAG} .

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
+    "serve-prd": "vue-cli-service serve --mode prd",
     "build": "vue-cli-service build",
+    "build-prd": "vue-cli-service build --mode prd",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@datadog/browser-rum": "^4.15.0",
     "axios": "^0.27.2",
     "chart.js": "^2.9.3",
     "chartjs-plugin-colorschemes": "^0.4.0",

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,23 @@ import axios from '@/axios/'
 import vuetify from '@/plugin/vuetify'
 import interval from '@/plugin/interval'
 import i18n from '@/i18n'
+import { datadogRum } from '@datadog/browser-rum'
+
+// RUM
+if (process.env.VUE_APP_RUM_ID !== '' && process.env.VUE_APP_RUM_TOKEN !== '') {
+  datadogRum.init({
+    // parameters: https://docs.datadoghq.com/real_user_monitoring/browser/#configuration
+    applicationId: process.env.VUE_APP_RUM_ID,
+    clientToken: process.env.VUE_APP_RUM_TOKEN,
+    site: 'datadoghq.com',
+    service: 'risken',
+    sampleRate: 100,
+    premiumSampleRate: 100,
+    trackInteractions: true,
+    defaultPrivacyLevel: 'mask-user-input',
+  })
+  datadogRum.startSessionReplayRecording()
+}
 
 Vue.prototype.$axios = axios
 Vue.config.productionTip = false

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,6 +944,26 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
+"@datadog/browser-core@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-core/-/browser-core-4.15.0.tgz#44efdec550c1923b61967490c7ac3fb93c390089"
+  integrity sha512-uLyCiksfrkrSdpYpfaS+e3feI0YQIRtJu5pEZpMrww9hvjY4XFdicG73Va8+O6WhZeGFfV13RMTlxWhsQSFA0w==
+
+"@datadog/browser-rum-core@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-rum-core/-/browser-rum-core-4.15.0.tgz#5c0c55881da161a47564228c25b0333f45f2a250"
+  integrity sha512-7HiOGO7Du5kNknGs0CzVrUzmdYRf+7I++d8EqIWIIb8KMx8eKaiCBlY1ac+0nTHrbQCdQuV4s6xFpKYpEa8oiA==
+  dependencies:
+    "@datadog/browser-core" "4.15.0"
+
+"@datadog/browser-rum@^4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-rum/-/browser-rum-4.15.0.tgz#c09995ba3ec0e9666fd75255c99c7cc7b51151db"
+  integrity sha512-4QHf84rC8CEkZbvPh1x48/fk3vv0CVy/aT2lX/da8raIHCyF5j/zXsKpMiV6DJ7ZSFaYIfiuinGiNKH/0cVf7Q==
+  dependencies:
+    "@datadog/browser-core" "4.15.0"
+    "@datadog/browser-rum-core" "4.15.0"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"


### PR DESCRIPTION
DataDog RUM（Real-User-Monitoring）を導入します。

- 本番、STG環境のみRUM設定をします
  - 本番、STGで同じRUMのID、トークンを使用します
  - DataDogの画面上で環境ごとにフィルタすることができます
  - 公式イメージビルド時にはRUMの設定は含みません
- DataDog RUMのブラウザSDKを使用します。詳細な設定は[公式ドキュメント](https://docs.datadoghq.com/ja/real_user_monitoring/installation/?tab=us) を参照してください
- 環境ごとでRUMを設定したりしなかったりしますが、RISKENのフロントエンドのビルドではvue-cliを使用してますのでVUE_APP変数を利用しています。詳細はvue-cliの[公式ドキュメント](https://cli.vuejs.org/guide/mode-and-env.html)を参照してください

- また、CodeBuildのbuildspecでGITHUB_USER, GITHUB_TOKENは不要になったので削除しました（OSS化のタイミングで不要になりました。削除漏れ）
