### PR TITLE
fix github_setting.name disabled flag

### DIFF
--- a/src/view/code/NewSettingDialog.vue
+++ b/src/view/code/NewSettingDialog.vue
@@ -42,8 +42,10 @@
                           $t(`item['` + gitHubForm.name.label + `']`) + ' *'
                         "
                         :placeholder="gitHubForm.name.placeholder"
-                        :disabled="isReadOnly || !!gitHubSetting.name"
-                        :filled="isReadOnly || !!gitHubSetting.name"
+                        :disabled="
+                          isReadOnly || gitHubSetting.github_setting_id
+                        "
+                        :filled="isReadOnly || gitHubSetting.github_setting_id"
                       ></v-text-field>
                     </v-col>
                     <v-col cols="5">


### PR DESCRIPTION
github settingのnameに1文字でも入力を入れるとdisabled,isReadOnlyのフラグが立って編集できなくなる問題を修正します。

他のデータソースと同様に、一度登録した後の編集は不可能にしています。