### PR TITLE
add: gcp cloudsploit upgrade btn

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -38,6 +38,7 @@ const en = {
     'AUTO GENERATE VERIFICATION CODE': 'AUTO GENERATE VERIFICATION CODE',
     'View registerd project tags': 'View registerd project tags',
     Recommendation: 'Recommendation',
+    Upgrade: 'Upgrade',
   },
   menu: {
     Home: 'Home',
@@ -201,6 +202,11 @@ const en = {
     'WPScan Random User Agent': 'Use a random user-agent for each scan',
     'WPScan WP Content Dir':
       'The wp-content directory if custom or not detected, such as "wp-content"',
+  },
+  version: {
+    version: 'version',
+    latest: 'latest',
+    old: 'old',
   },
   action: {
     '': '',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -38,6 +38,7 @@ const ja = {
     'AUTO GENERATE VERIFICATION CODE': '検証コードを自動生成する',
     'View registerd project tags': '登録済みのプロジェクトタグを確認する',
     Recommendation: '推奨アクションを確認する',
+    Upgrade: 'アップグレード',
   },
   menu: {
     Home: 'ホーム',
@@ -201,6 +202,11 @@ const ja = {
     'WPScan Random User Agent': 'スキャンごとにランダムなUAを使用する',
     'WPScan WP Content Dir':
       '「wp-content」ディレクトリを自動で検知できない場合に手動で設定する',
+  },
+  version: {
+    version: 'バージョン',
+    latest: '最新',
+    old: '旧',
   },
   action: {
     '': '',

--- a/src/view/google/GCPDataSource.vue
+++ b/src/view/google/GCPDataSource.vue
@@ -107,6 +107,12 @@
                   </v-chip>
                   <v-chip v-else color="grey" dark>Not configured</v-chip>
                 </template>
+                <template v-slot:[`item.specific_version`]="{ item }">
+                  <template v-if="item.specific_version">
+                    {{ $t(`version["old"]`) }} ({{ item.specific_version }})
+                  </template>
+                  <template v-else> {{ $t(`version["latest"]`) }} </template>
+                </template>
                 <template v-slot:[`item.scan_at`]="{ item }">
                   <v-chip v-if="item.scan_at">{{
                     item.scan_at | formatTime
@@ -293,6 +299,38 @@
                     <v-chip color="grey lighten-3">
                       {{ gcpDataSourceModel.scan_at | formatTime }}
                     </v-chip>
+                  </v-list-item-title>
+                </v-list-item-content>
+              </v-list-item>
+            </v-col>
+          </v-row>
+          <v-row dense v-if="!gcpForm.setupAll">
+            <v-col cols="8">
+              <v-list-item two-line>
+                <v-list-item-content>
+                  <v-list-item-subtitle>
+                    {{ $t(`version['version']`) }}
+                  </v-list-item-subtitle>
+                  <v-list-item-title
+                    class="headline"
+                    v-if="gcpDataSourceModel.specific_version"
+                  >
+                    {{ $t(`version['old']`) }} ({{
+                      gcpDataSourceModel.specific_version
+                    }})
+                    <v-btn
+                      text
+                      outlined
+                      color="blue darken-1"
+                      :loading="loading"
+                      @click="handleAttachSubmit"
+                    >
+                      <v-icon left>mdi-update</v-icon>
+                      {{ $t(`btn['Upgrade']`) }}
+                    </v-btn>
+                  </v-list-item-title>
+                  <v-list-item-title class="headline" v-else>
+                    {{ $t(`version['latest']`) }}
                   </v-list-item-title>
                 </v-list-item-content>
               </v-list-item>
@@ -504,6 +542,7 @@ export default {
         status: 0,
         status_detail: '',
         scan_at: 0,
+        specific_version: '',
       },
       table: {
         selected: [],
@@ -589,10 +628,10 @@ export default {
           value: 'gcp_id',
         },
         {
-          text: this.$i18n.t('item["GCP Organization"]'),
+          text: this.$i18n.t('version["version"]'),
           align: 'start',
           sortable: true,
-          value: 'gcp_organization_id',
+          value: 'specific_version',
         },
         {
           text: this.$i18n.t('item["GCP Project"]'),
@@ -692,6 +731,7 @@ export default {
           status: 0,
           status_detail: '',
           scan_at: 0,
+          specific_version: '',
         }
         if (
           res.data.data.gcp_data_source &&
@@ -704,6 +744,7 @@ export default {
           item.status = res.data.data.gcp_data_source.status
           item.status_detail = res.data.data.gcp_data_source.status_detail
           item.scan_at = res.data.data.gcp_data_source.scan_at
+          item.specific_version = res.data.data.gcp_data_source.specific_version
         }
         items.push(item)
       }

--- a/vue.config.js
+++ b/vue.config.js
@@ -12,11 +12,10 @@ module.exports = {
         target: "http://localhost:8000",
         logLevel: "debug",
         onProxyReq: (proxyReq) => {
-          // proxyReq.setHeader("x-amzn-oidc-identity", "alice");
-          proxyReq.setHeader("x-amzn-oidc-identity", "fixed-user-sub");
+          proxyReq.setHeader("x-amzn-oidc-identity", "alice");
           proxyReq.setHeader(
             "X-Amzn-Oidc-Data",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGljZSIsInVzZXJuYW1lIjoiYWxpY2UifQo=.iTH5EiE4epl0p7bw-8-x2kpURFZsYibqPQCtrOx52OY"
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGljZSIsInVzZXJuYW1lIjoiYWxpY2UiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhbGljZSJ9Cg==.iTH5EiE4epl0p7bw-8-x2kpURFZsYibqPQCtrOx52OY"
           );
         },
       },


### PR DESCRIPTION
GCPデータソースにバージョン情報を追加しました。
旧バージョンの場合はアップグレードボタンで最新バージョンに更新できるようにしました

![image](https://user-images.githubusercontent.com/25426601/208028126-48cab854-c120-4bf3-b290-7f50d0059e0e.png)

![image](https://user-images.githubusercontent.com/25426601/208028068-799ec9b8-6f10-48d3-aafc-e5031103601d.png)