### PR TITLE
add static link

### DIFF
--- a/codebuild/multi-arch/buildspec-image.yml
+++ b/codebuild/multi-arch/buildspec-image.yml
@@ -8,6 +8,7 @@ env:
     DOCKER_TOKEN: "/build/DOCKER_TOKEN"
     VUE_APP_RUM_ID: "/build/datadog/VUE_APP_RUM_ID"
     VUE_APP_RUM_TOKEN: "/build/datadog/VUE_APP_RUM_TOKEN"
+    VUE_APP_STATIC_LINK: "/build/web/VUE_APP_STATIC_LINK"
 
 phases:
   install:
@@ -38,6 +39,7 @@ phases:
       - echo Build web started on `date`
       - echo "VUE_APP_RUM_ID=${VUE_APP_RUM_ID}" > .env.prd
       - echo "VUE_APP_RUM_TOKEN=${VUE_APP_RUM_TOKEN}" >> .env.prd
+      - echo "VUE_APP_STATIC_LINK=${VUE_APP_STATIC_LINK}" >> .env.prd
 
       - echo Building the Docker images...
       - make build-ci -j BUILD_OPT="${BUILD_OPT}" IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_TAG=${TAG} IMAGE_REGISTRY=${REGISTRY}

--- a/src/component/AppDrawer.vue
+++ b/src/component/AppDrawer.vue
@@ -96,6 +96,19 @@
           </v-list-item>
         </template>
       </template>
+      <v-list-item
+        v-for="(item, key) in staticRoutes"
+        :key="`static-${key}`"
+        :href="item.url"
+        target="_blank"
+      >
+        <v-list-item-icon>
+          <v-icon>mdi-open-in-new</v-icon>
+        </v-list-item-icon>
+        <v-list-item-content>
+          <v-list-item-title v-text="item.title"></v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
     </v-list>
     <!-- <template v-slot:append>
       <template v-if="drawerWidth === 64">
@@ -123,7 +136,7 @@
   </v-navigation-drawer>
 </template>
 <script>
-import { appRoute as routes } from '@/router/config'
+import { appRoute as routes, staticRoutes } from '@/router/config'
 export default {
   name: 'AppDrawer',
   components: {},
@@ -142,6 +155,7 @@ export default {
       scrollSettings: {
         maxScrollbarLength: 160,
       },
+      staticRoutes: staticRoutes,
     }
   },
   computed: {
@@ -160,7 +174,6 @@ export default {
       immediate: true,
     },
   },
-  created() {},
   methods: {
     handleDrawerCollapse() {
       this.drawerWidth = this.drawerWidth === 256 ? 64 : 256

--- a/src/component/AppDrawer.vue
+++ b/src/component/AppDrawer.vue
@@ -96,19 +96,28 @@
           </v-list-item>
         </template>
       </template>
-      <v-list-item
-        v-for="(item, key) in staticRoutes"
-        :key="`static-${key}`"
-        :href="item.url"
-        target="_blank"
+      <v-list-group
+        prepend-icon="mdi-open-in-new"
+        no-action
+        v-if="staticRoutes.length > 0"
       >
-        <v-list-item-icon>
-          <v-icon>mdi-open-in-new</v-icon>
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title v-text="item.title"></v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
+        <template v-slot:activator>
+          <v-list-item-content>
+            <v-list-item-title v-text="$t(`item['Link']`)" />
+          </v-list-item-content>
+        </template>
+        <v-list-item
+          v-for="(item, key) in staticRoutes"
+          :key="`static-${key}`"
+          :href="item.url"
+          target="_blank"
+          rel="noopener"
+        >
+          <v-list-item-content>
+            <v-list-item-title v-text="item.title"></v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list-group>
     </v-list>
     <!-- <template v-slot:append>
       <template v-if="drawerWidth === 64">

--- a/src/component/AppDrawer.vue
+++ b/src/component/AppDrawer.vue
@@ -112,6 +112,7 @@
           :href="item.url"
           target="_blank"
           rel="noopener"
+          :risken-action-name="`click-link-${item.title}-from-menu-bar`"
         >
           <v-list-item-content>
             <v-list-item-title v-text="item.title"></v-list-item-title>

--- a/src/component/AppToolbar.vue
+++ b/src/component/AppToolbar.vue
@@ -68,6 +68,34 @@
           </v-list-item-group>
         </v-list>
       </v-menu>
+      <v-menu
+        offset-y
+        origin="center center"
+        class="elelvation-1"
+        transition="scale-transition"
+      >
+        <template v-slot:activator="{ on }">
+          <v-btn text slot="activator" v-on="on">
+            <v-icon>mdi-open-in-new</v-icon>
+            <span class="ml-2"> {{ $t(`item['Link']`) }} </span>
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-item
+            v-for="(item, key) in staticRoutes"
+            :key="`static-${key}`"
+            :href="item.url"
+            target="_blank"
+          >
+            <v-list-item-action class="mr-4">
+              <v-icon>mdi-open-in-new</v-icon>
+            </v-list-item-action>
+            <v-list-item-content>
+              <v-list-item-title v-text="item.title"></v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-menu>
       <v-menu offset-y origin="center center" transition="scale-transition">
         <template v-slot:activator="{ on }">
           <v-btn icon large text slot="activator" v-on="on">
@@ -198,6 +226,7 @@
   </v-app-bar>
 </template>
 <script>
+import { staticRoutes } from '@/router/config'
 import BottomSnackBar from '@/component/widget/snackbar/BottomSnackBar'
 import Util from '@/util'
 import store from '@/store'
@@ -251,6 +280,7 @@ export default {
         },
       ],
       isAdmin: false,
+      staticRoutes: staticRoutes,
     }
   },
   computed: {

--- a/src/component/AppToolbar.vue
+++ b/src/component/AppToolbar.vue
@@ -85,6 +85,7 @@
             v-for="(item, key) in staticRoutes"
             :key="`static-${key}`"
             :href="item.url"
+            rel="noopener"
             target="_blank"
           >
             <v-list-item-action class="mr-4">

--- a/src/component/AppToolbar.vue
+++ b/src/component/AppToolbar.vue
@@ -87,6 +87,7 @@
             :href="item.url"
             rel="noopener"
             target="_blank"
+            :risken-action-name="`click-link-${item.title}-from-header`"
           >
             <v-list-item-action class="mr-4">
               <v-icon>mdi-open-in-new</v-icon>

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -139,6 +139,7 @@ const en = {
     'Google Data Source ID': 'Google Data Source ID',
     Keyword: 'Keyword',
     ID: 'ID',
+    Link: 'Link',
     'Last Updated User': 'Last Updated User',
     'MAX Score': 'MAX Score',
     'Max Depth': 'MAX Depth',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -139,6 +139,7 @@ const ja = {
     Keyword: 'キーワード',
     'Gitleaks Status': 'Gitleaksステータス',
     ID: 'ID',
+    Link: 'リンク',
     'Last Updated User': '最終更新者',
     'MAX Score': 'MAXスコア',
     'Max Depth': 'スキャンの最大階層',

--- a/src/router/config.js
+++ b/src/router/config.js
@@ -462,3 +462,18 @@ export const appRoute = [
     ],
   },
 ]
+
+export const staticRoutes = getStaticRoutes()
+
+function getStaticRoutes() {
+  if (process.env.VUE_APP_STATIC_LINK == '') {
+    return []
+  }
+  try {
+    const jsonRoutes = JSON.parse(process.env.VUE_APP_STATIC_LINK)
+    return jsonRoutes
+    // エラー時は空のリストを返す
+  } catch (e) {
+    return []
+  }
+}


### PR DESCRIPTION
環境変数から静的なリンクを生成できるように修正します。
静的なリンクは、メニューとヘッダーに表示します。(フッターにも表示することを考えましたが、ヘッダが常に表示されているため冗長になるかと思い入れませんでした。)
環境変数は、mapのarrayで以下のように設定します。
```shell
VUE_APP_STATIC_LINK=[{"title":"sample","url":"https://example.com"},{"title":"document","url":"https://docs.security-hub.jp/"}]
```

メニューのサンプル
![image](https://user-images.githubusercontent.com/35591487/211790792-8910b8c0-6b7d-4dc4-a1c2-9dd5a2dd010a.png)

ヘッダのサンプル
![image](https://user-images.githubusercontent.com/35591487/211790879-7025f9d0-80c1-4426-99e1-69ade99c8330.png)

メニューのタイトルをクリックすることで、新タブでurlを表示します。
アイコンは固定にしていますが、環境変数で設定させるように修正することも可能です。
アイコンを動的にする場合、以下のように修正します。
 - メニューアイコンが指定されていない場合にのみ現在表示しているアイコンを表示する
 - 現在メニューに表示されている内容をサブメニューにして、メニューには`リンク`などを表示してそれをクリックすることでリンク一覧を表示する
   - アイコンを動的にした場合、リンクが開かれることが想定しづらくなる可能性があると考えたため

