### PR TITLE
Fix user

### DIFF
--- a/src/component/widget/list/User.vue
+++ b/src/component/widget/list/User.vue
@@ -48,7 +48,7 @@
           class="elevation-1"
           item-key="user_id"
           @click:row="handleSelectItem"
-          @update:page="loadList"
+          @update:page="refleshList"
         >
           <template v-slot:[`item.updated_at`]="{ item }">
             <v-chip>{{ item.updated_at | formatTime }}</v-chip>
@@ -115,6 +115,12 @@ export default {
           value: 'name',
         },
         {
+          text: this.$i18n.t('item["User Key"]'),
+          align: 'start',
+          sortable: false,
+          value: 'user_idp_key',
+        },
+        {
           text: this.$i18n.t('item["Updated"]'),
           align: 'center',
           sortable: false,
@@ -158,6 +164,7 @@ export default {
       return {
         user_id: user.user_id,
         name: user.name,
+        user_idp_key: user.user_idp_key,
         updated_at: user.updated_at,
       }
     },

--- a/src/view/iam/User.vue
+++ b/src/view/iam/User.vue
@@ -169,6 +169,15 @@
             filled
             disabled
           ></v-text-field>
+          <v-text-field
+            v-model="userModel.user_idp_key"
+            :counter="64"
+            :rules="userForm.user_idp_key.validator"
+            :label="$t(`item['` + userForm.user_idp_key.label + `']`) + ' *'"
+            :placeholder="userForm.user_idp_key.placeholder"
+            filled
+            disabled
+          ></v-text-field>
           <!-- Role List -->
           <div v-show="userModel.user_id">
             <v-toolbar flat color="white" v-show="userModel.user_id">
@@ -308,12 +317,14 @@ export default {
         clickNew: false,
         user_id: { label: 'ID', placeholder: '-' },
         name: { label: 'Name', placeholder: 'Please select user...' },
+        user_idp_key: { label: 'User Key'},
       },
       userIDList: [],
       userNameList: [],
       userModel: {
         user_id: '',
         name: '',
+        user_idp_key: '',
         role_cnt: 0,
         roles: '',
         updated_at: '',
@@ -372,6 +383,12 @@ export default {
           align: 'start',
           sortable: false,
           value: 'name',
+        },
+        {
+          text: this.$i18n.t('item["User Key"]'),
+          align: 'start',
+          sortable: false,
+          value: 'user_idp_key',
         },
         {
           text: this.$i18n.t('item["Roles"]'),
@@ -450,6 +467,7 @@ export default {
         const item = {
           user_id: user.user_id,
           name: user.name,
+          user_idp_key: user.user_idp_key,
           updated_at: user.updated_at,
           role_cnt: roles.length,
           roles: roles,
@@ -475,7 +493,6 @@ export default {
       const roles = await this.listRoleAPI('').catch((err) => {
         return Promise.reject(err)
       })
-
       roles.forEach(async (id) => {
         const role = await this.getRoleAPI(id).catch((err) => {
           return Promise.reject(err)
@@ -540,6 +557,7 @@ export default {
       this.userModel = {
         user_id: '',
         name: '',
+        user_idp_key: '',
         role_cnt: 0,
         roles: '',
         updated_at: '',
@@ -564,13 +582,13 @@ export default {
       if (this.searchModel.userID) {
         searchCond += '&user_id=' + this.searchModel.userID
       }
-
       this.refleshList(searchCond)
     },
     assignDataModel(item) {
-      this.awsuserModelModel = {
+      this.userModel = {
         user_id: '',
         name: '',
+        user_idp_key: '',
         role_cnt: 0,
         roles: '',
         updated_at: '',

--- a/src/view/iam/User.vue
+++ b/src/view/iam/User.vue
@@ -317,7 +317,7 @@ export default {
         clickNew: false,
         user_id: { label: 'ID', placeholder: '-' },
         name: { label: 'Name', placeholder: 'Please select user...' },
-        user_idp_key: { label: 'User Key'},
+        user_idp_key: { label: 'User Key' },
       },
       userIDList: [],
       userNameList: [],


### PR DESCRIPTION
ユーザー画面にuser_idp_keyを追加します
以下画面のイメージです。
- ユーザー一覧
![image](https://user-images.githubusercontent.com/35591487/218074556-fae021ff-103d-4dcf-953b-0aa8b2fadb03.png)
- ユーザー招待画面
![image](https://user-images.githubusercontent.com/35591487/218074658-341b23db-2d0a-43b6-9837-744216407d85.png)
- ユーザー詳細画面
![image](https://user-images.githubusercontent.com/35591487/218074696-855aab5a-2ebe-4bdd-870c-acfbc335e76c.png)

また、合わせてユーザー画面にアクセス時に初めてNewをクリックした際にエラーが発生していた問題を修正しました。
