### PR TITLE
fix: untag project

### DIFF
--- a/src/view/diagnosis/ApplicationScan.vue
+++ b/src/view/diagnosis/ApplicationScan.vue
@@ -707,6 +707,7 @@ export default {
     },
     async handleDeleteSubmit() {
       this.loading = true
+      await this.untagProjectAPI(this.getApplicationScanTag())
       await this.deleteItem(this.applicationScanModel.application_scan_id)
     },
     handleScan(item) {


### PR DESCRIPTION
アプリケーションスキャンの設定を削除でプロジェクトタグも削除するようにします