### PR TITLE
fix: project tag

### DIFF
--- a/src/view/code/NewSettingDialog.vue
+++ b/src/view/code/NewSettingDialog.vue
@@ -819,7 +819,7 @@ export default {
         return Promise.reject(err)
       })
       await this.tagProjectAPI(
-        'github:' + this.gitHubSetting.target_resource,
+        'github:' + this.gitHubSetting.name,
         'black'
       ).catch((err) => {
         return Promise.reject(err)


### PR DESCRIPTION
githubセッティングのプロジェクトタグがターゲットリソース名を指定していたが、Gitleaksなどターゲットリソースが同じでフィルタ条件を変更する場合にはタグが同一で視認性が悪いという指摘がありました。

nameを指定することでタグを明確に分けて登録することができますが、どうでしょうか？

ターゲットリソースにはGitHubのOrg名やUser名が入るので、これはこれで良い、ということであればPR取り下げます。