### PR TITLE
Fix user

### DIFF
--- a/src/component/widget/list/User.vue
+++ b/src/component/widget/list/User.vue
@@ -34,7 +34,7 @@
         <v-spacer />
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text class="pa-0" v-if="!isUserNotFound">
+      <v-card-text class="pa-0" v-if="!noUser">
         <v-data-table
           :headers="headers"
           :items="table.items"
@@ -55,13 +55,13 @@
           </template>
         </v-data-table>
       </v-card-text>
-      <template v-if="isUserNotFound">
+      <template v-if="noUser">
         <v-alert
-          >{{ $t("view.iam['No users found for your search criteria.']")
+          >{{ $t("view.iam['No users found for your search condition.']")
           }}<br />
           {{
             $t(
-              "view.iam['To reserve a user with a user key in the search criteria, press the Reserve button.']"
+              "view.iam['To reserve a user with a user key in the search condition, press the RESERVE button.']"
             )
           }}
         </v-alert>
@@ -119,7 +119,7 @@ export default {
         items: [],
       },
       users: [],
-      isUserNotFound: false,
+      noUser: false,
     }
   },
   computed: {
@@ -158,7 +158,7 @@ export default {
   methods: {
     async refleshList(searchCond) {
       this.loading = true
-      this.isUserNotFound = false
+      this.noUser = false
       this.table.options.page = 1
       this.clearList()
 
@@ -185,7 +185,7 @@ export default {
         this.searchModel.userName &&
         userIDs.length == 0
       ) {
-        this.isUserNotFound = true
+        this.noUser = true
       }
 
       this.loading = false

--- a/src/component/widget/list/User.vue
+++ b/src/component/widget/list/User.vue
@@ -66,7 +66,13 @@
           }}
         </v-alert>
         <v-card-actions class="justify-center">
-          <v-btn text outlined color="teal darken-1" @click="handleUserReserve">
+          <v-btn
+            text
+            outlined
+            color="teal darken-1"
+            risken-action-name="`click-handle-user-reserve"
+            @click="handleUserReserve"
+          >
             {{ $t(`btn['RESERVE']`) }}
           </v-btn>
         </v-card-actions>

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -328,10 +328,10 @@ const en = {
       'from the project.': 'from the project.',
       'Make sure to copy your access token now. You won’t be able to see it again!':
         'Make sure to copy your access token now. You won’t be able to see it again!',
-      'No users found for your search criteria.':
-        'No users found for your search criteria.',
-      'To reserve a user with a user key in the search criteria, press the Reserve button.':
-        'To reserve a user with a user key in the search criteria, press the Reserve button.',
+      'No users found for your search condition.':
+        'No users found for your search condition.',
+      'To reserve a user with a user key in the search condition, press the RESERVE button.':
+        'To reserve a user with a user key in the search condition, press the RESERVE button.',
       'User Reservation Description': `Roles can be reserved for new users.
         New users will be assigned to the reserved roles when they access the system.
         For existing users, please attach the role from the user screen.

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -159,6 +159,7 @@ const en = {
     Risk: 'Risk',
     Repository: 'Repository',
     RepositoryPattern: 'RepositoryPattern',
+    Reserved: 'Reserved',
     'Resource Name': 'Resource Name',
     'Resource Pattern': 'Resource Pattern',
     Resource: 'Resource',
@@ -189,6 +190,7 @@ const en = {
     Type: 'Type',
     Updated: 'Updated',
     'UpdatedAt Range': 'UpdatedAt Range',
+    User: 'User',
     'User Key': 'User Key',
     'Verification Code': 'Verification Code',
     'Webhook URL': 'Webhook URL',
@@ -326,6 +328,10 @@ const en = {
       'from the project.': 'from the project.',
       'Make sure to copy your access token now. You won’t be able to see it again!':
         'Make sure to copy your access token now. You won’t be able to see it again!',
+      'No users found for your search criteria.':
+        'No users found for your search criteria.',
+      'To reserve a user with a user key in the search criteria, press the Reserve button.':
+        'To reserve a user with a user key in the search criteria, press the Reserve button.',
       'User Reservation Description': `Roles can be reserved for new users.
         New users will be assigned to the reserved roles when they access the system.
         For existing users, please attach the role from the user screen.

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -327,9 +327,9 @@ const ja = {
       'from the project.': 'されます.',
       'Make sure to copy your access token now. You won’t be able to see it again!':
         'アクセストークンをコピーし大切に保管してください. この画面を閉じた後は再度見ることができなくなります.',
-      'No users found for your search criteria.':
+      'No users found for your search condition.':
         '検索した条件でユーザーが見つかりませんでした。',
-      'To reserve a user with a user key in the search criteria, press the Reserve button.':
+      'To reserve a user with a user key in the search condition, press the RESERVE button.':
         '検索条件のユーザーキーでユーザーの予約を行う場合には、予約ボタンを押してください。',
       'User Reservation Description': `新規ユーザに対してロールを予約することができます
       新規ユーザのアクセス時に予約されたロールへの割り当てが行われます

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -159,6 +159,7 @@ const ja = {
     Risk: 'リスク',
     Repository: 'リポジトリ',
     RepositoryPattern: 'リポジトリパターン',
+    Reserved: '予約済み',
     'Resource Name': 'リソース名',
     'Resource Pattern': 'リソースパターン',
     Resource: 'リソース',
@@ -189,6 +190,7 @@ const ja = {
     Type: 'タイプ',
     Updated: '更新日時',
     'UpdatedAt Range': '更新日（範囲）',
+    User: 'ユーザー',
     'User Key': 'ユーザキー',
     'Verification Code': '検証コード',
     'Webhook URL': 'ウェブフックURL',
@@ -325,6 +327,10 @@ const ja = {
       'from the project.': 'されます.',
       'Make sure to copy your access token now. You won’t be able to see it again!':
         'アクセストークンをコピーし大切に保管してください. この画面を閉じた後は再度見ることができなくなります.',
+      'No users found for your search criteria.':
+        '検索した条件でユーザーが見つかりませんでした。',
+      'To reserve a user with a user key in the search criteria, press the Reserve button.':
+        '検索条件のユーザーキーでユーザーの予約を行う場合には、予約ボタンを押してください。',
       'User Reservation Description': `新規ユーザに対してロールを予約することができます
       新規ユーザのアクセス時に予約されたロールへの割り当てが行われます
       既存のユーザに対しては、ユーザ画面からロールの紐付けを行ってください`,

--- a/src/mixin/api/iam.js
+++ b/src/mixin/api/iam.js
@@ -330,11 +330,12 @@ const iam = {
     },
 
     // UserReserved API
-    async listUserReservedAPI() {
+    async listUserReservedAPI(searchCond) {
       const res = await this.$axios
         .get(
           '/iam/list-user-reserved/?project_id=' +
-            this.$store.state.project.project_id
+            this.$store.state.project.project_id +
+            searchCond
         )
         .catch((err) => {
           return Promise.reject(err)

--- a/src/view/iam/User.vue
+++ b/src/view/iam/User.vue
@@ -615,15 +615,6 @@ export default {
       // Create/Delete User Reserved
       var searchCond = '&user_idp_key=' + this.userModel.user_idp_key
       const registeredUserReserveds = await this.listUserReservedAPI(searchCond)
-      // if (this.roleTable.selected.length == 0) {
-      //   registeredUserReserveds.forEach(async (ur) => {
-      //     await this.deleteUserReservedAPI(ur.user_reserved_id).catch((err) => {
-      //       this.$refs.snackbar.notifyError(err.response.data)
-      //       return Promise.reject(err)
-      //     })
-      //   })
-      //   return
-      // }
       this.roleTable.items.forEach(async (item) => {
         let attachRole = false
         this.roleTable.selected.some((selected) => {

--- a/src/view/iam/UserReservation.vue
+++ b/src/view/iam/UserReservation.vue
@@ -408,7 +408,7 @@ export default {
     async refleshList() {
       this.loading = true
       this.clearList()
-      const userReserveds = await this.listUserReservedAPI().catch((err) => {
+      const userReserveds = await this.listUserReservedAPI('').catch((err) => {
         this.clearList()
         return Promise.reject(err)
       })


### PR DESCRIPTION
ユーザー一覧画面にユーザー予約に関する内容を追加します
- ユーザー一覧のテーブルに予約されたユーザーを表示するように変更します
  - ユーザーキーをテーブルの一番左に表示し、ユーザーIDを表示しないように修正します
    - IDがユーザーとユーザー予約で意味合いが異なってしまうこと、ユーザーキーは必ず含まれていることをふまえました
    - 一覧画面でのユーザーIDでの検索も削除しています
- ユーザー予約の変更もユーザー画面で行えるように修正しました
  - ユーザーが存在する場合にはattach/detach roleを行い、ユーザー予約の場合にはput/delete user reservedを行います
- INVITE画面にてユーザー名で検索した結果が0件だった場合に、その検索ワードでユーザーを予約する導線を作成しました

以下、画面イメージです
- ユーザー一覧
![image](https://user-images.githubusercontent.com/35591487/220099491-46002ac9-1d04-4928-b9f0-cc19a8b8337b.png)

- INVITE
![image](https://user-images.githubusercontent.com/35591487/220100066-f8792f21-4985-4cab-bb5d-6b4e1667b7ea.png)
