### PR TITLE
fix: datasource warning

### DIFF
--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -323,8 +323,28 @@ let mixin = {
           return 'Unknown'
       }
     },
+    isOKStatus: (status) => {
+      if (Number(status) === 1) return true
+      return false
+    },
     isInProgressDataSourceStatus: (status) => {
       if (Number(status) === 3) return true
+      return false
+    },
+    isErrorStatus: (status) => {
+      if (Number(status) === 4) return true
+      return false
+    },
+    hasDataSourceWarning(datasource) {
+      if (
+        !this.isOKStatus(datasource.status) &&
+        !this.isErrorStatus(datasource.status)
+      ) {
+        return false
+      }
+      if (datasource.status_detail && datasource.status_detail != '') {
+        return true
+      }
       return false
     },
     getDataSourceStatusColor: (status) => {

--- a/src/view/aws/DataSource.vue
+++ b/src/view/aws/DataSource.vue
@@ -104,6 +104,11 @@
                     {{ getDataSourceStatusText(item.status) }}
                   </v-chip>
                   <v-chip v-else color="grey" dark>Not configured</v-chip>
+                  <v-icon
+                    v-if="hasDataSourceWarning(item)"
+                    color="yellow darken-2"
+                    >mdi-alert</v-icon
+                  >
                 </template>
                 <template v-slot:[`item.scan_at`]="{ item }">
                   <v-chip v-if="item.scan_at">{{
@@ -650,7 +655,7 @@ export default {
         {
           text: this.$i18n.t('item["Status"]'),
           align: 'start',
-          width: '12%',
+          width: '14%',
           sortable: false,
           value: 'status',
         },

--- a/src/view/google/GCPDataSource.vue
+++ b/src/view/google/GCPDataSource.vue
@@ -106,6 +106,11 @@
                     {{ getDataSourceStatusText(item.status) }}
                   </v-chip>
                   <v-chip v-else color="grey" dark>Not configured</v-chip>
+                  <v-icon
+                    v-if="hasDataSourceWarning(item)"
+                    color="yellow darken-2"
+                    >mdi-alert</v-icon
+                  >
                 </template>
                 <template v-slot:[`item.specific_version`]="{ item }">
                   <template v-if="item.specific_version">
@@ -617,7 +622,7 @@ export default {
         {
           text: this.$i18n.t('item["Status"]'),
           align: 'start',
-          width: '12%',
+          width: '14%',
           sortable: true,
           value: 'status',
         },


### PR DESCRIPTION
AWSとGCPのステータス画面で、status_detailがある場合にはワーニングアイコンを表示するようにします。
（OKとErrorステータスのみ）

![image](https://user-images.githubusercontent.com/25426601/220235546-077addc9-a473-4142-8c27-8588d82d5b7e.png)
