### PR TITLE
fix: project_id=undefind bug

### DIFF
--- a/src/mixin/api/alert.js
+++ b/src/mixin/api/alert.js
@@ -8,7 +8,7 @@ const alert = {
       const res = await this.$axios
         .get(
           '/alert/list-alert/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             statusParam
         )
         .catch((err) => {
@@ -26,7 +26,7 @@ const alert = {
           '/alert/list-history/?alert_id=' +
             alert_id +
             '&project_id=' +
-            this.$store.state.project.project_id
+            this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -43,7 +43,7 @@ const alert = {
           '/alert/list-rel_alert_finding/?alert_id=' +
             alert_id +
             '&project_id=' +
-            this.$store.state.project.project_id
+            this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -69,7 +69,7 @@ const alert = {
       const res = await this.$axios
         .get(
           '/alert/list-condition/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             enabledParam
         )
         .catch((err) => {
@@ -85,7 +85,7 @@ const alert = {
       const rules = await this.$axios
         .get(
           '/alert/list-condition_rule/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&alert_condition_id=' +
             alert_condition_id
         )
@@ -102,7 +102,7 @@ const alert = {
       const notis = await this.$axios
         .get(
           '/alert/list-condition_notification/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&alert_condition_id=' +
             alert_condition_id
         )
@@ -117,7 +117,7 @@ const alert = {
 
     async deleteAlertCondition(alert_condition_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert_condition_id: alert_condition_id,
       }
       await this.$axios.post('/alert/delete-condition/', param).catch((err) => {
@@ -135,9 +135,9 @@ const alert = {
     },
     async putDefaultAlertCondition() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert_condition: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           description: 'RISKEN Alert',
           severity: 'medium',
           and_or: 'and',
@@ -153,9 +153,9 @@ const alert = {
     },
     async putAlertConditionRule(alert_condition_id, alert_rule_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert_cond_rule: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           alert_condition_id: alert_condition_id,
           alert_rule_id: alert_rule_id,
         },
@@ -171,9 +171,7 @@ const alert = {
     // AlertRule
     async listAlertRule() {
       const res = await this.$axios
-        .get(
-          '/alert/list-rule/?project_id=' + this.$store.state.project.project_id
-        )
+        .get('/alert/list-rule/?project_id=' + this.getCurrentProjectID())
         .catch((err) => {
           return Promise.reject(err)
         })
@@ -185,7 +183,7 @@ const alert = {
 
     async deleteAlertRule(alert_rule_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert_rule_id: alert_rule_id,
       }
       await this.$axios.post('/alert/delete-rule/', param).catch((err) => {
@@ -200,9 +198,9 @@ const alert = {
     },
     async putDefaultAlertRule() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert_rule: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           name: 'over0.8',
           score: 0.8,
           resource_name: '',
@@ -225,8 +223,7 @@ const alert = {
     async listAlertNotification() {
       const res = await this.$axios
         .get(
-          '/alert/list-notification/?project_id=' +
-            this.$store.state.project.project_id
+          '/alert/list-notification/?project_id=' + this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -239,7 +236,7 @@ const alert = {
 
     async deleteAlertNotification(notification_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         notification_id: notification_id,
       }
       await this.$axios
@@ -257,7 +254,7 @@ const alert = {
 
     async testAlertNotification(notification_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         notification_id: notification_id,
       }
       await this.$axios
@@ -271,7 +268,7 @@ const alert = {
     async analyzeAlert(alert_condition_id) {
       const cond_ids = [alert_condition_id]
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert_condition_id: cond_ids,
       }
       await this.$axios.post('/alert/analyze-alert/', param).catch((err) => {

--- a/src/mixin/api/aws.js
+++ b/src/mixin/api/aws.js
@@ -5,9 +5,7 @@ const aws = {
   methods: {
     async listAWSAPI() {
       const res = await this.$axios
-        .get(
-          '/aws/list-aws/?project_id=' + this.$store.state.project.project_id
-        )
+        .get('/aws/list-aws/?project_id=' + this.getCurrentProjectID())
         .catch((err) => {
           return Promise.reject(err)
         })
@@ -18,7 +16,7 @@ const aws = {
     },
     async deleteAWSAPI(awsID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         aws_id: awsID,
       }
       const res = await this.$axios
@@ -30,9 +28,9 @@ const aws = {
     },
     async putAWSAPI(name, aws_account_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         aws: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           name: name,
           aws_account_id: aws_account_id,
         },
@@ -50,7 +48,7 @@ const aws = {
         .get(
           '/aws/list-datasource/' +
             '?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&aws_id=' +
             aws_id +
             '&data_source=' +
@@ -66,7 +64,7 @@ const aws = {
     },
     async detachAWSDataSourceAPI(aws_id, aws_data_source_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         aws_id: aws_id,
         aws_data_source_id: aws_data_source_id,
       }
@@ -88,7 +86,7 @@ const aws = {
 
     async invokeAWSScanAPI(aws_id, aws_data_source_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         aws_id: aws_id,
         aws_data_source_id: aws_data_source_id,
         scan_only: false, // optional

--- a/src/mixin/api/code.js
+++ b/src/mixin/api/code.js
@@ -16,7 +16,7 @@ const code = {
       return res.data.data.code_data_source
     },
     async listGitHubSettingAPI(github_setting_id) {
-      let query = '?project_id=' + this.$store.state.project.project_id
+      let query = '?project_id=' + this.getCurrentProjectID()
       if (github_setting_id) {
         query += '&github_setting_id=' + github_setting_id
       }
@@ -32,7 +32,7 @@ const code = {
     },
     async putGitHubSettingAPI(github_setting) {
       const paramGitHubSetting = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         github_setting: github_setting,
       }
       const res = await this.$axios
@@ -47,7 +47,7 @@ const code = {
     },
     async deleteGitHubSettingAPI(github_setting_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         github_setting_id: github_setting_id,
       }
       await this.$axios
@@ -58,7 +58,7 @@ const code = {
     },
     async putGitleaksSettingAPI(gitleaks_setting) {
       const paramGitleaksSetting = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         gitleaks_setting: gitleaks_setting,
       }
       const res = await this.$axios
@@ -73,7 +73,7 @@ const code = {
     },
     async deleteGitleaksSettingAPI(github_setting_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         github_setting_id: github_setting_id,
       }
       await this.$axios
@@ -84,7 +84,7 @@ const code = {
     },
     async putDependencySettingAPI(dependency_setting) {
       const paramDependencySetting = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         dependency_setting: dependency_setting,
       }
       const res = await this.$axios
@@ -99,7 +99,7 @@ const code = {
     },
     async deleteDependencySettingAPI(github_setting_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         github_setting_id: github_setting_id,
       }
       await this.$axios
@@ -110,7 +110,7 @@ const code = {
     },
     async invokeScanGitleaksAPI(github_setting_id, fullscan) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         github_setting_id: github_setting_id,
         full_scan: fullscan,
       }
@@ -122,7 +122,7 @@ const code = {
     },
     async invokeScanDependencyAPI(github_setting_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         github_setting_id: github_setting_id,
       }
       await this.$axios

--- a/src/mixin/api/diagnosis.js
+++ b/src/mixin/api/diagnosis.js
@@ -11,7 +11,7 @@ const diagnosis = {
             '?diagnosis_data_source_id=' +
             this.wpscan_datasource_id +
             '&project_id=' +
-            this.$store.state.project.project_id
+            this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -26,7 +26,7 @@ const diagnosis = {
         .get(
           '/diagnosis/list-wpscan-setting/' +
             '?project_id=' +
-            this.$store.state.project.project_id
+            this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -38,9 +38,9 @@ const diagnosis = {
     },
     async putWPScanSettingAPI(wpscan_setting_id, target_url, options, scan_at) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         wpscan_setting: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           wpscan_setting_id: wpscan_setting_id,
           diagnosis_data_source_id: this.wpscan_datasource_id,
           target_url: target_url,
@@ -61,7 +61,7 @@ const diagnosis = {
     },
     async deleteWPScanSettingAPI(wpscan_setting_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         wpscan_setting_id: wpscan_setting_id,
       }
       await this.$axios
@@ -76,7 +76,7 @@ const diagnosis = {
       const res = await this.$axios
         .get(
           '/diagnosis/list-portscan-setting/?project_id=' +
-            this.$store.state.project.project_id
+            this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -93,9 +93,9 @@ const diagnosis = {
       target
     ) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         portscan_setting: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           diagnosis_data_source_id: diagnosisDataSourceID,
           portscan_setting_id: portscanSettingID,
           name: name,
@@ -117,7 +117,7 @@ const diagnosis = {
     },
     async deletePortscanSettingAPI(portscanSettingID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         portscan_setting_id: portscanSettingID,
       }
       const res = await this.$axios
@@ -130,7 +130,7 @@ const diagnosis = {
     async listPortscanTargetAPI(portscan_setting_id) {
       var url =
         '/diagnosis/list-portscan-target/?project_id=' +
-        this.$store.state.project.project_id
+        this.getCurrentProjectID()
       if (portscan_setting_id != 0) {
         url = url + '&portscan_setting_id=' + portscan_setting_id
       }
@@ -144,9 +144,9 @@ const diagnosis = {
     },
     async putPortscanTargetAPI(portscanSettingID, portscanTargetID, target) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         portscan_target: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           portscan_setting_id: portscanSettingID,
           portscan_target_id: portscanTargetID,
           target: target,
@@ -162,7 +162,7 @@ const diagnosis = {
     },
     async deletePortscanTargetAPI(portscanTargetID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         portscan_target_id: portscanTargetID,
       }
       const res = await this.$axios
@@ -176,7 +176,7 @@ const diagnosis = {
       const res = await this.$axios
         .get(
           '/diagnosis/list-application-scan/?project_id=' +
-            this.$store.state.project.project_id
+            this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -193,9 +193,9 @@ const diagnosis = {
       scanType
     ) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         application_scan: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           diagnosis_data_source_id: diagnosisDataSourceID,
           application_scan_id: applicationScanSettingID,
           name: name,
@@ -214,7 +214,7 @@ const diagnosis = {
     },
     async deleteApplicationScanAPI(applicationScanSettingID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         application_scan_id: applicationScanSettingID,
       }
       const res = await this.$axios
@@ -227,7 +227,7 @@ const diagnosis = {
     async getApplicationScanBasicSettingAPI(application_scan_id) {
       var url =
         '/diagnosis/get-application-scan-basic-setting/?project_id=' +
-        this.$store.state.project.project_id
+        this.getCurrentProjectID()
       if (application_scan_id != 0) {
         url = url + '&application_scan_id=' + application_scan_id
       }
@@ -247,9 +247,9 @@ const diagnosis = {
       max_children
     ) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         application_scan_basic_setting: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           application_scan_id: applicationScanSettingID,
           application_scan_basic_setting_id: applicationScanBasicSettingID,
           target: target,
@@ -267,7 +267,7 @@ const diagnosis = {
     },
     async deleteApplicationScanBasicSettingAPI(applicationScanBasicSettingID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         application_scan_basic_setting_id: applicationScanBasicSettingID,
       }
       const res = await this.$axios
@@ -279,7 +279,7 @@ const diagnosis = {
     },
     async invokeDiagnosisScanAPI(setting_id, diagnosis_data_source_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         setting_id: setting_id,
         diagnosis_data_source_id: diagnosis_data_source_id,
       }

--- a/src/mixin/api/finding.js
+++ b/src/mixin/api/finding.js
@@ -8,7 +8,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-finding/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             searchCond
         )
         .catch((err) => {
@@ -23,7 +23,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-finding/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             searchCond
         )
         .catch((err) => {
@@ -38,7 +38,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-finding/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&resource_name=' +
             resource_name
         )
@@ -54,7 +54,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/get-finding/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&finding_id=' +
             id
         )
@@ -73,7 +73,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-finding-tag/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&finding_id=' +
             id
         )
@@ -89,7 +89,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-finding-tag-name/?project_id=' +
-            this.$store.state.project.project_id
+            this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -103,7 +103,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/get-pend-finding/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&finding_id=' +
             id
         )
@@ -119,7 +119,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-resource/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             searchCond
         )
         .catch((err) => {
@@ -134,7 +134,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/get-resource/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&resource_id=' +
             id
         )
@@ -150,7 +150,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-resource-tag/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&resource_id=' +
             id
         )
@@ -166,7 +166,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-resource-tag-name/?project_id=' +
-            this.$store.state.project.project_id
+            this.getCurrentProjectID()
         )
         .catch((err) => {
           return Promise.reject(err)
@@ -179,9 +179,9 @@ const finding = {
 
     async tagFinding(findingID, tag) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         tag: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           finding_id: findingID,
           tag: tag,
         },
@@ -194,7 +194,7 @@ const finding = {
 
     async untagFinding(finding_tag_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         finding_tag_id: finding_tag_id,
       }
       await this.$axios.post('/finding/untag-finding/', param).catch((err) => {
@@ -216,10 +216,10 @@ const finding = {
     },
     async putPendFinding(finding_id, note, expired_at) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         pend_finding: {
           finding_id: finding_id,
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           note: note,
         },
       }
@@ -235,7 +235,7 @@ const finding = {
     },
     async deleteFinding(finding_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         finding_id: finding_id,
       }
       await this.$axios.post('/finding/delete-finding/', param).catch((err) => {
@@ -245,7 +245,7 @@ const finding = {
     },
     async deleteResourceAPI(resource_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         resource_id: resource_id,
       }
       await this.$axios
@@ -260,7 +260,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/list-finding-setting/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             statusParam
         )
         .catch((err) => {
@@ -280,7 +280,7 @@ const finding = {
     },
     async deleteFindingSettingAPI(finding_setting_id) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         finding_setting_id: finding_setting_id,
       }
       await this.$axios
@@ -293,7 +293,7 @@ const finding = {
       const res = await this.$axios
         .get(
           '/finding/get-recommend/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&finding_id=' +
             findingID
         )

--- a/src/mixin/api/google.js
+++ b/src/mixin/api/google.js
@@ -5,9 +5,7 @@ const google = {
   methods: {
     async listGCPAPI() {
       const res = await this.$axios
-        .get(
-          '/google/list-gcp/?project_id=' + this.$store.state.project.project_id
-        )
+        .get('/google/list-gcp/?project_id=' + this.getCurrentProjectID())
         .catch((err) => {
           return Promise.reject(err)
         })
@@ -28,7 +26,7 @@ const google = {
 
     async deleteGCPAPI(gcpID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         gcp_id: gcpID,
       }
       const res = await this.$axios

--- a/src/mixin/api/iam.js
+++ b/src/mixin/api/iam.js
@@ -60,7 +60,7 @@ const iam = {
       const res = await this.$axios
         .get(
           '/iam/list-role/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             searchCond
         )
         .catch((err) => {
@@ -86,7 +86,7 @@ const iam = {
       const res = await this.$axios
         .get(
           '/iam/get-role/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&role_id=' +
             roleID
         )
@@ -105,10 +105,10 @@ const iam = {
     },
     async putRoleAPI(name) {
       const roleParam = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         role: {
           name: name,
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
         },
       }
       const res = await this.$axios
@@ -120,7 +120,7 @@ const iam = {
     },
     async attachRoleAPI(userID, roleID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         user_id: userID,
         role_id: roleID,
       }
@@ -145,7 +145,7 @@ const iam = {
     },
     async detachRoleAPI(userID, roleID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         user_id: userID,
         role_id: roleID,
       }
@@ -170,7 +170,7 @@ const iam = {
     },
     async deleteRoleAPI(roleID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         role_id: roleID,
       }
       const res = await this.$axios
@@ -186,7 +186,7 @@ const iam = {
       const res = await this.$axios
         .get(
           '/iam/list-policy/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             searchCond
         )
         .catch((err) => {
@@ -201,7 +201,7 @@ const iam = {
       const res = await this.$axios
         .get(
           '/iam/get-policy/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&policy_id=' +
             policyID
         )
@@ -212,7 +212,7 @@ const iam = {
     },
     async attachPolicyAPI(roleID, policyID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         role_id: roleID,
         policy_id: policyID,
       }
@@ -225,7 +225,7 @@ const iam = {
     },
     async detachPolicyAPI(roleID, policyID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         role_id: roleID,
         policy_id: policyID,
       }
@@ -238,7 +238,7 @@ const iam = {
     },
     async deletePolicyAPI(policyID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         policy_id: policyID,
       }
       const res = await this.$axios
@@ -262,7 +262,7 @@ const iam = {
       const res = await this.$axios
         .get(
           '/iam/list-access-token/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             searchCond
         )
         .catch((err) => {
@@ -291,7 +291,7 @@ const iam = {
     },
     async attachTokenRoleAPI(accessTokenID, roleID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         access_token_id: accessTokenID,
         role_id: roleID,
       }
@@ -304,7 +304,7 @@ const iam = {
     },
     async detachTokenRoleAPI(accessTokenID, roleID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         access_token_id: accessTokenID,
         role_id: roleID,
       }
@@ -318,7 +318,7 @@ const iam = {
 
     async deleteAccessTokenAPI(accessTokenID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         access_token_id: accessTokenID,
       }
       const res = await this.$axios
@@ -334,7 +334,7 @@ const iam = {
       const res = await this.$axios
         .get(
           '/iam/list-user-reserved/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             searchCond
         )
         .catch((err) => {
@@ -355,7 +355,7 @@ const iam = {
     },
     async deleteUserReservedAPI(reservedID) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         reserved_id: reservedID,
       }
       const res = await this.$axios

--- a/src/mixin/api/project.js
+++ b/src/mixin/api/project.js
@@ -33,7 +33,7 @@ const project = {
 
     async updateProjectAPI(name) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         name: name,
       }
       const res = await this.$axios
@@ -49,7 +49,7 @@ const project = {
 
     async tagProjectAPI(tag, color) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         tag: tag,
         color: color,
       }
@@ -62,7 +62,7 @@ const project = {
     },
     async untagProjectAPI(tag) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         tag: tag,
       }
       const res = await this.$axios
@@ -74,7 +74,7 @@ const project = {
     },
     async deleteProjectAPI() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
       }
       const res = await this.$axios
         .post('/project/delete-project/', param)

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -560,17 +560,23 @@ let mixin = {
     },
     async handleNewProjectTag() {
       this.projectTagModel = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         tag: '',
       }
       this.projectTagDialog = true
     },
     async handleEditProjectTag(tag) {
       this.projectTagModel = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         tag: tag.tag,
       }
       this.projectTagDialog = true
+    },
+    getCurrentProjectID() {
+      if (this.$store.state.project.project_id) {
+        return this.$store.state.project.project_id
+      }
+      return ''
     },
   },
 }

--- a/src/view/Dashboard.vue
+++ b/src/view/Dashboard.vue
@@ -370,7 +370,7 @@ export default {
     async setUser() {
       this.raw.invitedUser = []
       const userIDs = await this.listUserAPI(
-        '&project_id=' + this.$store.state.project.project_id
+        '&project_id=' + this.getCurrentProjectID()
       ).catch((err) => {
         return Promise.reject(err)
       })

--- a/src/view/alert/Alert.vue
+++ b/src/view/alert/Alert.vue
@@ -514,9 +514,9 @@ export default {
     // Pending alert
     async putAlertStatus(status) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           alert_id: this.alertModel.alert_id,
           alert_condition_id: this.alertModel.alert_condition_id,
           description: this.alertModel.description,

--- a/src/view/alert/Condition.vue
+++ b/src/view/alert/Condition.vue
@@ -761,9 +761,9 @@ export default {
     // Put Condition
     async putItem() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert_condition: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           alert_condition_id: this.dataModel.alert_condition_id,
           description: this.dataModel.description,
           severity: this.dataModel.severity,
@@ -814,7 +814,7 @@ export default {
         // Set param for delete request.
         let uri = '/alert/delete-condition_rule/'
         let param = {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           alert_condition_id: this.dataModel.alert_condition_id,
           alert_rule_id: item.alert_rule_id,
         }
@@ -823,9 +823,9 @@ export default {
             // If the rule is selected, change to param for put request.
             uri = '/alert/put-condition_rule/'
             param = {
-              project_id: this.$store.state.project.project_id,
+              project_id: this.getCurrentProjectID(),
               alert_cond_rule: {
-                project_id: this.$store.state.project.project_id,
+                project_id: this.getCurrentProjectID(),
                 alert_condition_id: this.dataModel.alert_condition_id,
                 alert_rule_id: item.alert_rule_id,
               },
@@ -891,7 +891,7 @@ export default {
         // Set param for delete request.
         let uri = '/alert/delete-condition_notification/'
         let param = {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           alert_condition_id: this.dataModel.alert_condition_id,
           notification_id: item.notification_id,
         }
@@ -900,9 +900,9 @@ export default {
             // If the rule is selected, change to param for put request.
             uri = '/alert/put-condition_notification/'
             param = {
-              project_id: this.$store.state.project.project_id,
+              project_id: this.getCurrentProjectID(),
               alert_cond_notification: {
-                project_id: this.$store.state.project.project_id,
+                project_id: this.getCurrentProjectID(),
                 alert_condition_id: this.dataModel.alert_condition_id,
                 notification_id: item.notification_id,
                 cache_second: this.getNotiCacheSecound(

--- a/src/view/alert/Notification.vue
+++ b/src/view/alert/Notification.vue
@@ -540,9 +540,9 @@ export default {
     // put
     async putItem() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         notification: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           notification_id: this.dataModel.notification_id,
           type: this.dataModel.type,
           name: this.dataModel.name,

--- a/src/view/alert/Rule.vue
+++ b/src/view/alert/Rule.vue
@@ -501,9 +501,9 @@ export default {
     // put
     async putItem() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         alert_rule: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           alert_rule_id: this.dataModel.alert_rule_id,
           name: this.dataModel.name,
           score: this.dataModel.score,

--- a/src/view/aws/DataSource.vue
+++ b/src/view/aws/DataSource.vue
@@ -844,11 +844,11 @@ export default {
         scan_at = this.awsModel.scan_at
       }
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         attach_data_source: {
           aws_id: this.awsModel.aws_id,
           aws_data_source_id: this.awsModel.aws_data_source_id,
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           assume_role_arn: this.awsModel.assume_role_arn,
           external_id: this.awsModel.external_id,
           status: 2, // CONFIGURED

--- a/src/view/code/NewSettingDialog.vue
+++ b/src/view/code/NewSettingDialog.vue
@@ -806,7 +806,7 @@ export default {
       const github_setting = {
         github_setting_id: this.gitHubSetting.github_setting_id,
         name: this.gitHubSetting.name,
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         type: this.getGitHubTypeCode(this.gitHubSetting.type_text),
         base_url: this.gitHubSetting.base_url,
         target_resource: this.gitHubSetting.target_resource,
@@ -843,7 +843,7 @@ export default {
       const paramGitleaksSetting = {
         github_setting_id: gitHubSettingID,
         code_data_source_id: this.gitleaks_datasource_id,
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         repository_pattern: this.gitleaksSetting.repository_pattern,
         scan_public: Boolean(this.gitleaksSetting.scan_public),
         scan_internal: Boolean(this.gitleaksSetting.scan_internal),
@@ -877,7 +877,7 @@ export default {
       const paramDependencySetting = {
         github_setting_id: gitHubSettingID,
         code_data_source_id: this.dependency_datasource_id,
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         status: 2, // CONFIGURED
         status_detail:
           'Configured at: ' + Util.formatDate(new Date(), 'yyyy/MM/dd HH:mm'),

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1495,10 +1495,7 @@ export default {
     },
     async handleActivateItem(row) {
       this.loading = true
-      await this.deletePendFinding(
-        this.$store.state.project.project_id,
-        row.finding_id
-      )
+      await this.deletePendFinding(this.getCurrentProjectID(), row.finding_id)
       this.finishSuccess('Success: Activated.')
     },
     async handleActivateSelected() {
@@ -1507,7 +1504,7 @@ export default {
       this.table.selected.forEach(async (item) => {
         if (!item.finding_id) return
         await this.deletePendFinding(
-          this.$store.state.project.project_id,
+          this.getCurrentProjectID(),
           item.finding_id
         )
       })

--- a/src/view/finding/Setting.vue
+++ b/src/view/finding/Setting.vue
@@ -460,9 +460,9 @@ export default {
     // Update
     async putFindingSetting() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         finding_setting: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           resource_name: this.dataModel.resource_name,
           setting: JSON.stringify({
             score_coefficient: parseFloat(this.dataModel.score_coefficient),
@@ -490,9 +490,9 @@ export default {
     // Activate/Deactivate
     async putFindingSettingStatus(status) {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         finding_setting: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           resource_name: this.dataModel.resource_name,
           setting: this.dataModel.setting,
           status: Number(this.getFindingSettingStatus(status)),

--- a/src/view/google/GCP.vue
+++ b/src/view/google/GCP.vue
@@ -544,9 +544,9 @@ export default {
     },
     async putItem() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         gcp: {
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           name: this.gcpModel.name,
           gcp_organization_id: this.gcpModel.gcp_organization_id,
           gcp_project_id: this.gcpModel.gcp_project_id,

--- a/src/view/google/GCPDataSource.vue
+++ b/src/view/google/GCPDataSource.vue
@@ -762,9 +762,7 @@ export default {
     },
     async listGCP() {
       const res = await this.$axios
-        .get(
-          '/google/list-gcp/?project_id=' + this.$store.state.project.project_id
-        )
+        .get('/google/list-gcp/?project_id=' + this.getCurrentProjectID())
         .catch((err) => {
           return Promise.reject(err)
         })
@@ -785,7 +783,7 @@ export default {
         const res = await this.$axios
           .get(
             '/google/get-gcp-datasource/?project_id=' +
-              this.$store.state.project.project_id +
+              this.getCurrentProjectID() +
               '&gcp_id=' +
               this.gcpModel.gcp_id +
               '&google_data_source_id=' +
@@ -847,7 +845,7 @@ export default {
     },
     async detachDataSource() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         gcp_id: this.gcpDataSourceModel.gcp_id,
         google_data_source_id: this.gcpDataSourceModel.google_data_source_id,
       }
@@ -876,11 +874,11 @@ export default {
         scan_at = this.gcpDataSourceModel.scan_at
       }
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         gcp_data_source: {
           gcp_id: this.gcpDataSourceModel.gcp_id,
           google_data_source_id: this.gcpDataSourceModel.google_data_source_id,
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           status: 2, // CONFIGURED
           status_detail:
             'Configured at: ' + Util.formatDate(new Date(), 'yyyy/MM/dd HH:mm'),
@@ -896,7 +894,7 @@ export default {
     },
     async scanDataSource() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         gcp_id: this.gcpDataSourceModel.gcp_id,
         google_data_source_id: this.gcpDataSourceModel.google_data_source_id,
         scan_only: false, // option

--- a/src/view/iam/AccessToken.vue
+++ b/src/view/iam/AccessToken.vue
@@ -716,10 +716,10 @@ export default {
     async putItem() {
       this.loading = true
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         access_token: {
           access_token_id: this.dataModel.access_token_id,
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           name: this.dataModel.name,
           description: this.dataModel.description,
           expired_at: this.convertToUnixTime(this.dataModel.expired_at),

--- a/src/view/iam/Policy.vue
+++ b/src/view/iam/Policy.vue
@@ -467,10 +467,10 @@ export default {
     },
     async putItem() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         policy: {
           name: this.policyModel.name,
-          project_id: this.$store.state.project.project_id,
+          project_id: this.getCurrentProjectID(),
           action_ptn: this.policyModel.action_ptn,
           resource_ptn: '.*', //this.policyModel.resource_ptn,
         },

--- a/src/view/iam/User.vue
+++ b/src/view/iam/User.vue
@@ -448,7 +448,7 @@ export default {
   },
   methods: {
     async refleshList(userName, userID) {
-      let searchCond = '&project_id=' + this.$store.state.project.project_id
+      let searchCond = '&project_id=' + this.getCurrentProjectID()
       if (userName) {
         searchCond += '&name=' + userName
       }
@@ -632,7 +632,7 @@ export default {
             return
           }
           const param = {
-            project_id: this.$store.state.project.project_id,
+            project_id: this.getCurrentProjectID(),
             user_reserved: {
               role_id: item.role_id,
               user_idp_key: this.userModel.user_idp_key,

--- a/src/view/iam/UserReservation.vue
+++ b/src/view/iam/UserReservation.vue
@@ -486,7 +486,7 @@ export default {
 
       this.loading = true
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         user_reserved: {
           reserved_id: this.dataModel.reserved_id,
           role_id: this.roleTable.selected[0].role_id,

--- a/src/view/osint/DataSource.vue
+++ b/src/view/osint/DataSource.vue
@@ -648,13 +648,13 @@ export default {
   methods: {
     async displayOSINT() {
       var isSuccess = true
-      const list = await this.listOSINT(
-        this.$store.state.project.project_id
-      ).catch((err) => {
-        this.finishError(err.response.data)
-        this.clearList()
-        isSuccess = false
-      })
+      const list = await this.listOSINT(this.getCurrentProjectID()).catch(
+        (err) => {
+          this.finishError(err.response.data)
+          this.clearList()
+          isSuccess = false
+        }
+      )
       if (!isSuccess || !list.osint) {
         this.osintList = []
         return
@@ -669,7 +669,7 @@ export default {
         return
       }
       const resOsint = await this.getOSINT(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         this.dataModel.osint_id
       ).catch((err) => {
         this.finishError(err.response.data)
@@ -681,7 +681,7 @@ export default {
         return
       }
       const resListDS = await this.listOSINTDataSource(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         this.dataModel.osint_id
       ).catch((err) => {
         this.finishError(err.response.data)
@@ -705,7 +705,7 @@ export default {
           max_score: ds.max_score,
         }
         const rel = await this.listRelOSINTDataSource(
-          this.$store.state.project.project_id,
+          this.getCurrentProjectID(),
           this.dataModel.osint_id,
           ds.osint_data_source_id
         ).catch((err) => {
@@ -737,7 +737,7 @@ export default {
     async detachDataSource() {
       var isSuccess = true
       await this.deleteRelOSINTDataSource(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         this.dataModel.rel_osint_data_source_id
       ).catch((err) => {
         this.finishError(err.response.data)
@@ -747,7 +747,7 @@ export default {
         return
       }
       await this.deleteDetectWordByRelOsintDataSourceID(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         this.dataModel.rel_osint_data_source_id
       ).catch((err) => {
         this.finishError(err.response)
@@ -777,7 +777,7 @@ export default {
         isPutDetectWord = true
       }
       await this.attachRelOSINTDataSource(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         this.dataModel.rel_osint_data_source_id,
         this.dataModel.osint_data_source_id,
         this.dataModel.osint_id,
@@ -800,7 +800,7 @@ export default {
       var isSuccess = true
       this.dataModel.detectWords = []
       const detectWords = await this.listDetectWord(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         this.dataModel.rel_osint_data_source_id
       ).catch((err) => {
         this.finishError(err.response.data)
@@ -814,7 +814,7 @@ export default {
     },
     async putWord(rel_osint_data_source_id, word) {
       await this.putDetectWord(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         rel_osint_data_source_id,
         word
       ).catch((err) => {
@@ -823,7 +823,7 @@ export default {
     },
     async deleteWord(osint_detect_word_id) {
       await this.deleteDetectWord(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         osint_detect_word_id
       ).catch((err) => {
         this.finishError(err.response.data)
@@ -833,7 +833,7 @@ export default {
     // Scan
     async scanDataSource() {
       const param = {
-        project_id: this.$store.state.project.project_id,
+        project_id: this.getCurrentProjectID(),
         rel_osint_data_source_id: this.dataModel.rel_osint_data_source_id,
       }
       await this.$axios.post('/osint/invoke-scan/', param).catch((err) => {

--- a/src/view/osint/OSINT.vue
+++ b/src/view/osint/OSINT.vue
@@ -390,14 +390,14 @@ export default {
   methods: {
     async displayList() {
       var isSuccess = true
-      const list = await this.listOSINT(
-        this.$store.state.project.project_id
-      ).catch((err) => {
-        this.finishError(err.response.data)
-        this.clearList()
-        isSuccess = false
-        return
-      })
+      const list = await this.listOSINT(this.getCurrentProjectID()).catch(
+        (err) => {
+          this.finishError(err.response.data)
+          this.clearList()
+          isSuccess = false
+          return
+        }
+      )
       if (!isSuccess || !list.osint) {
         this.clearList()
         return
@@ -411,13 +411,12 @@ export default {
     },
     async deleteItem(osintID) {
       var isSuccess = true
-      await this.deleteOSINT(
-        this.$store.state.project.project_id,
-        osintID
-      ).catch((err) => {
-        this.finishError(err.response.data)
-        isSuccess = false
-      })
+      await this.deleteOSINT(this.getCurrentProjectID(), osintID).catch(
+        (err) => {
+          this.finishError(err.response.data)
+          isSuccess = false
+        }
+      )
       if (!isSuccess) {
         return
       }
@@ -425,7 +424,7 @@ export default {
     },
     async putItem() {
       const res = await this.putOSINT(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         this.dataModel.osint_id,
         this.dataModel.resource_type,
         this.dataModel.resource_name
@@ -434,7 +433,7 @@ export default {
         return
       }
       await this.AttachReferenceDataSource(
-        this.$store.state.project.project_id,
+        this.getCurrentProjectID(),
         res.osint.osint_id,
         this.dataModel.resource_type
       )

--- a/src/view/report/Finding.vue
+++ b/src/view/report/Finding.vue
@@ -524,7 +524,7 @@ export default {
       let url = ''
       url = '/report/get-report/?project_id='
       const res = await this.$axios
-        .get(url + this.$store.state.project.project_id + searchCond)
+        .get(url + this.getCurrentProjectID() + searchCond)
         .catch((err) => {
           this.clearList()
           return Promise.reject(err)
@@ -559,9 +559,7 @@ export default {
         let condDate = '&from_date=' + Util.formatDate(fDate, 'yyyy-MM-dd')
         condDate += '&to_date=' + Util.formatDate(tDate, 'yyyy-MM-dd')
         const res = await this.$axios
-          .get(
-            url + this.$store.state.project.project_id + searchCond + condDate
-          )
+          .get(url + this.getCurrentProjectID() + searchCond + condDate)
           .catch((err) => {
             this.clearList()
             return Promise.reject(err)
@@ -658,7 +656,7 @@ export default {
       const res = await this.$axios
         .get(
           '/report/get-report/?project_id=' +
-            this.$store.state.project.project_id +
+            this.getCurrentProjectID() +
             '&from_date=' +
             this.lastMonth +
             '&to_date=' +


### PR DESCRIPTION
プロジェクトを選択していない場合に、リクエストパラメータ `project_id=undefind` になってしまうバグを修正します