### PR TITLE
fix: notification throttle label

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -145,7 +145,7 @@ const en = {
     Namespace: 'Namespace',
     Notificationns: 'Notificationns',
     'Notification ID': 'Notification ID',
-    'Notification cache term': 'Notification cache term',
+    'Notification throttle': 'Notification throttle',
     'Original Score': 'Original Score',
     'OSINT ID': 'OSINT ID',
     'OSINT Relation ID': 'OSINT Reration ID',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -145,7 +145,7 @@ const ja = {
     Namespace: 'ネームスペース',
     Notificationns: '通知設定',
     'Notification ID': '通知ID',
-    'Notification cache term': '通知キャッシュ期間',
+    'Notification throttle': '通知の抑制期間',
     'Original Score': 'オリジナルスコア',
     'OSINT ID': 'OSINT ID',
     'OSINT Relation ID': 'OSINT関連ID',

--- a/src/view/alert/Condition.vue
+++ b/src/view/alert/Condition.vue
@@ -518,19 +518,19 @@ export default {
           ],
         },
         noti_cache: {
-          label: 'Notification cache term',
+          label: 'Notification throttle',
           placeholder: '1 hour',
-          list: ['No Cache', '1 hour', '1 day', '1 week', '1 month'],
+          list: ['None', '1 hour', '1 day', '1 week', '1 month'],
           validator: [
-            (v) => !!v || 'Notification cache term is required',
+            (v) => !!v || 'Notification throttle is required',
             (v) =>
               !v ||
-              v === 'No Cache' ||
+              v === 'None' ||
               v === '1 hour' ||
               v === '1 day' ||
               v === '1 week' ||
               v === '1 month' ||
-              'Notification cache term is invalid',
+              'Notification throttle is invalid',
           ],
         },
         enabled: { label: 'Enabled', placeholder: 'true' },
@@ -1005,7 +1005,7 @@ export default {
     getNotiCacheText(sec) {
       switch (sec) {
         case 1:
-          return 'No Cache'
+          return 'None'
         case 60 * 60:
           return '1 hour'
         case 60 * 60 * 24:
@@ -1020,7 +1020,7 @@ export default {
     },
     getNotiCacheSecound(text) {
       switch (text) {
-        case 'No Cache':
+        case 'None':
           return 1
         case '1 hour':
           return 60 * 60


### PR DESCRIPTION
通知キャッシュ時間というのが分かりづらい（内部実装の視点の表現）ため、通知の抑制期間というラベルに変更します（他のサービスで利用されている表現）