### PR TITLE
Fix performance

### DIFF
--- a/src/axios/index.js
+++ b/src/axios/index.js
@@ -8,7 +8,7 @@ let PENDING_REQUESTS = 0
 
 const axios = Axios.create({
   baseURL: '/api/v1',
-  timeout: 10000,
+  timeout: 20000,
 })
 axios.interceptors.request.use(
   (config) => {

--- a/src/view/Dashboard.vue
+++ b/src/view/Dashboard.vue
@@ -279,7 +279,7 @@ export default {
       this.raw.highScoreFindingGoogle = google
     },
     async setStoreFinding() {
-      const storeFindings = await this.getFindingCount(0, '', 1)
+      const storeFindings = await this.getFindingCount(0, 'RISKEN', 1)
       this.status.tutorial.storeFindings = storeFindings > 0
     },
     async getFindingCount(fromScore, dataSource, limit) {

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -15,7 +15,7 @@
       </v-row>
       <v-form ref="searchForm">
         <v-row justify="center" align-content="center">
-          <v-col cols="2" class="px-2">
+          <v-col cols="2" class="px-1">
             <v-text-field
               outlined
               dense
@@ -27,7 +27,19 @@
               v-model="searchModel.findingID"
             />
           </v-col>
-          <v-col cols="3" class="px-2">
+          <v-col cols="2" class="px-1">
+            <v-text-field
+              outlined
+              dense
+              clearable
+              hide-details
+              background-color="white"
+              :placeholder="searchForm.alertID.placeholder"
+              :loading="loading"
+              v-model="searchModel.alertID"
+            />
+          </v-col>
+          <v-col cols="3" class="px-1">
             <v-combobox
               multiple
               outlined
@@ -43,24 +55,6 @@
               :loading="loading"
               v-model="searchModel.dataSource"
               ref="refDataSource"
-            />
-          </v-col>
-          <v-col cols="2" class="px-2">
-            <v-combobox
-              multiple
-              outlined
-              dense
-              clearable
-              small-chips
-              deletable-chips
-              hide-details
-              background-color="white"
-              :label="$t(`item['` + searchForm.tag.label + `']`)"
-              :placeholder="searchForm.tag.placeholder"
-              :items="searchForm.tagList"
-              :loading="loading"
-              v-model="searchModel.tag"
-              ref="refTag"
             />
           </v-col>
           <v-col cols="3" align-self="end" class="text-right">
@@ -150,19 +144,26 @@
         </v-row>
         <transition name="fade">
           <v-row v-show="searchMenuDetail">
-            <v-col cols="2" class="px-2">
-              <v-text-field
+            <v-col cols="3" class="px-1">
+              <v-combobox
+                multiple
                 outlined
                 dense
                 clearable
+                small-chips
+                deletable-chips
                 hide-details
                 background-color="white"
-                :placeholder="searchForm.alertID.placeholder"
+                :label="$t(`item['` + searchForm.tag.label + `']`)"
+                :placeholder="searchForm.tag.placeholder"
+                :items="searchForm.tagList"
                 :loading="loading"
-                v-model="searchModel.alertID"
+                v-model="searchModel.tag"
+                ref="refTag"
               />
             </v-col>
-            <v-col cols="4" class="px-2">
+
+            <v-col cols="4" class="px-1">
               <v-combobox
                 multiple
                 outlined


### PR DESCRIPTION
- ダッシュボードの重いAPIリクエストを修正します
- APIリクエストのタイムアウト時間を20秒まで緩和します
- Finding検索フィールドをみなします（アラート経由での画面遷移が多いのでよく使われる項目を上部に表示されるようにします）