### PR TITLE
fix datasource

### DIFF
--- a/src/view/aws/DataSource.vue
+++ b/src/view/aws/DataSource.vue
@@ -985,6 +985,7 @@ export default {
         aws_id: this.awsModel.aws_id,
         aws_account_id: this.awsModel.aws_account_id,
         aws_data_source_id: '',
+        name: this.awsModel.name,
         data_source: '',
         max_score: '',
         assume_role_arn: '',

--- a/src/view/osint/DataSource.vue
+++ b/src/view/osint/DataSource.vue
@@ -92,6 +92,11 @@
                   <v-chip v-else color="grey" variant="flat"
                     >Not configured</v-chip
                   >
+                  <v-icon
+                    v-if="hasDataSourceWarning(item.value)"
+                    color="yellow-darken-4"
+                    >mdi-alert</v-icon
+                  >
                 </template>
                 <template v-slot:[`item.scan_at`]="{ item }">
                   <v-chip v-if="item.value.scan_at">{{
@@ -254,7 +259,7 @@
                     {{ $t(`item['` + form.status_detail.label + `']`) }}
                   </span>
                 </v-card-title>
-                <v-card-text>
+                <v-card-text class="wrap">
                   {{ dataModel.status_detail }}
                 </v-card-text>
               </v-card>


### PR DESCRIPTION
AWS
- セレクトメニューが[object Object]になる問題が修正しきれていなかったため対応します
- データソースを選択した際にeditDialogが出るタイミングでobjectになっていたものを修正

OSINT
- AWS,GCPなどと同様にステータスがOKかつdetailが存在する場合にアラートアイコンを出します