### PR TITLE
add gitleaks scan result

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -39,6 +39,7 @@ const en = {
     'View registerd project tags': 'View registerd project tags',
     Recommendation: 'Recommendation',
     Upgrade: 'Upgrade',
+    CHECK: 'CHECK',
   },
   menu: {
     Home: 'Home',
@@ -364,6 +365,9 @@ const en = {
     },
     osint: {
       'Activate DataSource': 'Activate DataSource',
+    },
+    code: {
+      'Scan History': 'Scan History',
     },
   },
 }

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -39,6 +39,7 @@ const ja = {
     'View registerd project tags': '登録済みのプロジェクトタグを確認する',
     Recommendation: '推奨アクションを確認する',
     Upgrade: 'アップグレード',
+    CHECK: '確認',
   },
   menu: {
     Home: 'ホーム',
@@ -361,6 +362,9 @@ const ja = {
     },
     osint: {
       'Activate DataSource': '登録時にDataSourceを有効化する',
+    },
+    code: {
+      'Scan History': 'スキャン履歴',
     },
   },
 }

--- a/src/mixin/api/code.js
+++ b/src/mixin/api/code.js
@@ -108,6 +108,23 @@ const code = {
           return Promise.reject(err)
         })
     },
+    async listGitleaksCacheAPI(github_setting_id) {
+      const query =
+        '?project_id=' +
+        this.getCurrentProjectID() +
+        '&github_setting_id=' +
+        github_setting_id
+
+      const res = await this.$axios
+        .get('/code/list-gitleaks-cache/' + query)
+        .catch((err) => {
+          return Promise.reject(err)
+        })
+      if (!res.data || !res.data.data || !res.data.data.gitleaks_cache) {
+        return []
+      }
+      return res.data.data.gitleaks_cache
+    },
     async invokeScanGitleaksAPI(github_setting_id, fullscan) {
       const param = {
         project_id: this.getCurrentProjectID(),

--- a/src/view/code/GitleaksCache.vue
+++ b/src/view/code/GitleaksCache.vue
@@ -1,0 +1,135 @@
+<template>
+  <v-dialog max-width="50%" v-model="showDialog">
+    <v-card>
+      <v-card-title>
+        {{ $t(`view.code['Scan History']`) }}
+        <v-spacer></v-spacer>
+        <v-text-field
+          v-model="search"
+          append-icon="mdi-magnify"
+          label="Search"
+          single-line
+          hide-details
+          clearable
+          density="compact"
+        ></v-text-field>
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-text class="pa-0">
+        <v-data-table
+          :headers="headers"
+          :items="table.items"
+          :loading="loading"
+          :items-per-page-options="table.footer.itemsPerPageOptions"
+          :items-per-page="table.options.itemsPerPage"
+          :sort-by="table.options.sortBy"
+          :showCurrentPage="table.footer.showCurrentPage"
+          :search="search"
+          locale="ja-jp"
+          loading-text="Loading..."
+          no-data-text="No data."
+          class="elevation-1"
+          item-key="user_id"
+        >
+          <template v-slot:[`item.scan_at`]="{ item }">
+            <v-chip>{{ formatTime(item.value.scan_at) }}</v-chip>
+          </template>
+        </v-data-table>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn text outlined color="grey-darken-1" @click="handleCancel">
+          {{ $t(`btn['CANCEL']`) }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import mixin from '@/mixin'
+import code from '@/mixin/api/code'
+import { VDataTable } from 'vuetify/labs/VDataTable'
+export default {
+  mixins: [mixin, code],
+  components: {
+    VDataTable,
+  },
+  name: 'GitleaksCache',
+  props: {
+    gitleaksCacheDialog: Boolean,
+    githubSettingID: Number,
+  },
+  data() {
+    return {
+      loading: false,
+      searchModel: {
+        repositoryName: null,
+      },
+      search: '',
+      table: {
+        options: {
+          page: 1,
+          itemsPerPage: 10,
+          sortBy: ['repository_full_name'],
+        },
+        total: 0,
+        footer: {
+          itemsPerPageOptions: [{ value: 10, title: '10' }],
+          showCurrentPage: true,
+        },
+        items: [],
+      },
+      users: [],
+      noUser: false,
+    }
+  },
+  computed: {
+    showDialog: {
+      get() {
+        return this.gitleaksCacheDialog
+      },
+      set() {
+        this.handleCancel()
+      },
+    },
+    headers() {
+      return [
+        {
+          title: this.$i18n.t('item["Repository"]'),
+          align: 'start',
+          sortable: false,
+          key: 'repository_full_name',
+        },
+        {
+          title: this.$i18n.t('item["ScanAt"]'),
+          align: 'start',
+          sortable: false,
+          key: 'scan_at',
+        },
+      ]
+    },
+  },
+  mounted() {
+    this.loading = true
+    this.loadList('')
+    this.loading = false
+  },
+  methods: {
+    async loadList() {
+      const gitleaksCaches = await this.listGitleaksCacheAPI(
+        this.githubSettingID
+      ).catch((err) => {
+        return Promise.reject(err)
+      })
+      if (!gitleaksCaches) {
+        return
+      }
+      this.table.items = gitleaksCaches
+    },
+    handleCancel() {
+      this.$emit('handleGitleaksCacheResponse', false)
+    },
+  },
+}
+</script>

--- a/src/view/code/GitleaksCache.vue
+++ b/src/view/code/GitleaksCache.vue
@@ -7,7 +7,7 @@
         <v-text-field
           v-model="search"
           append-icon="mdi-magnify"
-          label="Search"
+          label="Filter"
           single-line
           hide-details
           clearable
@@ -38,7 +38,7 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn text outlined color="grey-darken-1" @click="handleCancel">
+        <v-btn variant="outlined" color="grey-darken-1" @click="handleCancel">
           {{ $t(`btn['CANCEL']`) }}
         </v-btn>
       </v-card-actions>
@@ -63,9 +63,6 @@ export default {
   data() {
     return {
       loading: false,
-      searchModel: {
-        repositoryName: null,
-      },
       search: '',
       table: {
         options: {
@@ -80,8 +77,6 @@ export default {
         },
         items: [],
       },
-      users: [],
-      noUser: false,
     }
   },
   computed: {

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -193,7 +193,7 @@
                   </v-col>
                 </v-row>
                 <v-row>
-                  <v-col cols="3">
+                  <v-col cols="2">
                     <v-list-item two-line>
                       <v-list-item-subtitle>
                         {{ $t(`item['Data Source ID']`) }}
@@ -203,7 +203,7 @@
                       </v-list-item-title>
                     </v-list-item>
                   </v-col>
-                  <v-col cols="3">
+                  <v-col cols="2">
                     <v-list-item>
                       <v-list-item-title class="text-h5">
                         <v-list-item-subtitle>
@@ -215,7 +215,7 @@
                       </v-list-item-title>
                     </v-list-item>
                   </v-col>
-                  <v-col cols="3">
+                  <v-col cols="2">
                     <v-list-item>
                       <v-list-item-title class="text-h5">
                         <v-list-item-subtitle>
@@ -250,13 +250,35 @@
                         <v-list-item-subtitle>
                           {{ $t(`item['ScanAt']`) }}
                         </v-list-item-subtitle>
-                        <v-chip
-                          color="grey-lighten-3"
-                          v-if="gitleaksSetting.scan_at"
-                        >
+                        <v-chip v-if="gitleaksSetting.scan_at">
                           {{ formatTime(gitleaksSetting.scan_at) }}
                         </v-chip>
                         <v-chip v-else>Not yet scan...</v-chip>
+                      </v-list-item-title>
+                    </v-list-item>
+                  </v-col>
+                  <v-col cols="3" v-if="getStatus(gitleaksSetting) == 1">
+                    <v-list-item>
+                      <v-list-item-title>
+                        <v-list-item-subtitle>
+                          {{ $t(`view.code['Scan History']`) }}
+                        </v-list-item-subtitle>
+                        <v-btn
+                          @click="openGitleaksCacheDialog()"
+                          density="comfortable"
+                          variant="outlined"
+                          color="cyan-darken-2"
+                        >
+                          {{ $t(`btn['CHECK']`) }}
+                        </v-btn>
+                        <gitleaks-cache
+                          v-if="gitleaksCacheDialog"
+                          :gitleaksCacheDialog="gitleaksCacheDialog"
+                          :githubSettingID="githubSettingID"
+                          @handleGitleaksCacheResponse="
+                            this.gitleaksCacheDialog = false
+                          "
+                        />
                       </v-list-item-title>
                     </v-list-item>
                   </v-col>
@@ -506,10 +528,7 @@
                             <v-list-item-subtitle>
                               {{ $t(`item['ScanAt']`) }}
                             </v-list-item-subtitle>
-                            <v-chip
-                              color="grey-lighten-3"
-                              v-if="dependencySetting.scan_at"
-                            >
+                            <v-chip v-if="dependencySetting.scan_at">
                               {{ formatTime(dependencySetting.scan_at) }}
                             </v-chip>
                             <v-chip v-else>Not yet scan...</v-chip>
@@ -618,9 +637,13 @@ import Util from '@/util'
 import mixin from '@/mixin'
 import project from '@/mixin/api/project'
 import code from '@/mixin/api/code'
+import GitleaksCache from './GitleaksCache.vue'
 export default {
   name: 'SettingDialog',
   mixins: [mixin, project, code],
+  components: {
+    GitleaksCache,
+  },
   props: {
     isReadOnly: {
       type: Boolean,
@@ -693,6 +716,8 @@ export default {
       isEnabledDependency: this.gitHubModel.isEnabledDependency,
       isDeleteGitleaks: false,
       isDeleteDependency: false,
+      gitleaksCacheDialog: false,
+      githubSettingID: 0,
       loading: false,
       gitHubForm: {
         valid: false,
@@ -1030,6 +1055,10 @@ export default {
     },
     handleChangeStatus() {
       this.e6 = 2
+    },
+    openGitleaksCacheDialog() {
+      this.gitleaksCacheDialog = true
+      this.githubSettingID = this.gitHubSetting.github_setting_id
     },
   },
 }


### PR DESCRIPTION
以下を解決するため、gitleaksのスキャン履歴を確認できるダイアログを追加します
- resourceを確認しないとどのリポジトリがスキャンされたかを確認できない
- repository patternのフィルタと可視性が正しく設定できているかを確認しづらい

イメージ
![image](https://github.com/ca-risken/web/assets/35591487/02e75a83-0d08-4ac1-97db-1a1fef6abe40)
![image](https://github.com/ca-risken/web/assets/35591487/c12aa63f-e916-4bc2-b390-4b3f4f843682)


