### PR TITLE
fix datatable

### DIFF
--- a/src/view/iam/Policy.vue
+++ b/src/view/iam/Policy.vue
@@ -67,7 +67,6 @@
                 class="elevation-1"
                 item-key="policy_id"
                 @click:row="handleRowClick"
-                @update:page="loadList"
               >
                 <template v-slot:[`item.avator`]>
                   <v-avatar class="ma-3" size="48px">
@@ -411,12 +410,8 @@ export default {
       this.loading = true
       let items = []
       let policyNames = []
-      const from =
-        (this.table.options.page - 1) * this.table.options.itemsPerPage
-      const to = from + this.table.options.itemsPerPage
-      const ids = this.policies.slice(from, to)
       await Promise.all(
-        ids.map(async (id) => {
+        this.policies.map(async (id) => {
           const policy = await this.getPolicyAPI(id).catch((err) => {
             this.clearList()
             return Promise.reject(err)

--- a/src/view/iam/Role.vue
+++ b/src/view/iam/Role.vue
@@ -66,7 +66,6 @@
                 class="elevation-1"
                 item-key="role_id"
                 @click:row="handleRowClick"
-                @update:page="loadList"
               >
                 <template v-slot:[`item.avator`]>
                   <v-avatar class="ma-3" size="48px">
@@ -463,12 +462,8 @@ export default {
       this.loading = true
       let items = []
       let roleNames = []
-      const from =
-        (this.table.options.page - 1) * this.table.options.itemsPerPage
-      const to = from + this.table.options.itemsPerPage
-      const ids = this.roles.slice(from, to)
       await Promise.all(
-        ids.map(async (id) => {
+        this.roles.map(async (id) => {
           const role = await this.getRoleAPI(id).catch((err) => {
             this.clearList()
             return Promise.reject(err)

--- a/src/view/iam/User.vue
+++ b/src/view/iam/User.vue
@@ -49,8 +49,9 @@
           <v-card>
             <v-divider></v-divider>
             <v-card-text class="pa-0">
-              <v-data-table
+              <v-data-table-server
                 :headers="headers"
+                :items-length="table.total"
                 :items="table.items"
                 :loading="loading"
                 :sort-by="table.options.sortBy"
@@ -58,14 +59,13 @@
                 :items-per-page="table.options.itemsPerPage"
                 :items-per-page-options="table.footer.itemsPerPageOptions"
                 :items-per-page-text="table.footer.itemsPerPageText"
-                :showCurrentPage="table.footer.showCurrentPage"
+                :show-current-page="table.footer.showCurrentPage"
                 locale="ja-jp"
                 loading-text="Loading..."
                 no-data-text="No data."
                 class="elevation-1"
                 item-key="user_id"
-                @click:row="handleRowClick"
-                @update:page="loadList"
+                @update:options="updateOptions"
               >
                 <template v-slot:[`item.avator`]>
                   <v-avatar class="ma-2">
@@ -109,7 +109,7 @@
                     </v-list>
                   </v-menu>
                 </template>
-              </v-data-table>
+              </v-data-table-server>
             </v-card-text>
           </v-card>
         </v-col>
@@ -306,7 +306,7 @@ import mixin from '@/mixin'
 import iam from '@/mixin/api/iam'
 import BottomSnackBar from '@/component/widget/snackbar/BottomSnackBar.vue'
 import UserList from '@/component/widget/list/UserList.vue'
-import { VDataTable } from 'vuetify/labs/VDataTable'
+import { VDataTable, VDataTableServer } from 'vuetify/labs/VDataTable'
 export default {
   name: 'UserManagement',
   mixins: [mixin, iam],
@@ -314,6 +314,7 @@ export default {
     BottomSnackBar,
     UserList,
     VDataTable,
+    VDataTableServer,
   },
   data() {
     return {
@@ -706,6 +707,11 @@ export default {
         updated_at: '',
       }
       this.userModel = Object.assign(this.userModel, item)
+    },
+    updateOptions(options) {
+      this.table.options.page = options.page
+      this.table.options.itemsPerPage = options.itemsPerPage
+      this.loadList(true)
     },
   },
 }


### PR DESCRIPTION
page更新時にAPIで情報を取得するv-data-tableの表示がおかしかったため修正します

### User
v-data-table-serverを使用するように変更(Findingなどと同じ形式)

### Role,Policy
プロジェクト単位で、多すぎるデータ量になることが想定されないため、逐次APIを叩く形式をやめます
画面のロード時、検索時に一括でデータを取得するように変更