### PR TITLE
fix update alert first viewed

### DIFF
--- a/src/mixin/api/alert.js
+++ b/src/mixin/api/alert.js
@@ -60,9 +60,9 @@ const alert = {
       })
     },
 
-    async putAlertFirstViewedAt(alert_id) {
+    async putAlertFirstViewedAt(project_id, alert_id) {
       const param = {
-        project_id: this.getCurrentProjectID(),
+        project_id: project_id,
         alert_id: alert_id,
       }
       await this.$axios

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -640,18 +640,22 @@ let mixin = {
     async UpdateAlertFirstViewedAt() {
       if (!this.$route.query) return
       const query = this.$route.query
+      let project_id = 0
       let alert_id = 0
       let from = ''
       if (query.from && query.from != '') {
         from = query.from
       }
+      if (query.project_id && query.project_id != '') {
+        project_id = parseInt(query.project_id)
+      }
       if (query.alert_id && query.alert_id != '') {
         alert_id = parseInt(query.alert_id)
       }
-      if (!alert_id || from == '') {
+      if (!project_id || !alert_id || from == '') {
         return
       }
-      await this.putAlertFirstViewedAt(alert_id)
+      await this.putAlertFirstViewedAt(project_id, alert_id)
     },
   },
 }


### PR DESCRIPTION
未ログイン時、プロジェクトが選択されていない時、別のプロジェクトが既に選択されている場合にも正しく登録が行えるようにストレージの値でなくパスパラメータのプロジェクトIDを使用するように変更します