### PR TITLE
Fix ux

### DIFF
--- a/src/component/AppToolbar.vue
+++ b/src/component/AppToolbar.vue
@@ -6,7 +6,7 @@
     <v-app-bar-title>
       <v-menu
         location="bottom"
-        class="elelvation-1"
+        class="elevation-1"
         transition="scale-transition"
       >
         <template v-slot:activator="{ props }">
@@ -31,11 +31,7 @@
     <v-btn icon @click="handleFullScreen()">
       <v-icon icon="mdi-fullscreen" size="x-large" />
     </v-btn>
-    <v-menu
-      location="bottom"
-      class="elelvation-1"
-      transition="scale-transition"
-    >
+    <v-menu location="bottom" class="elevation-1" transition="scale-transition">
       <template v-slot:activator="{ props }">
         <v-btn v-bind="props" variant="text">
           <v-icon size="x-large" icon="mdi-web" />
@@ -55,11 +51,7 @@
         </v-list-item>
       </v-list>
     </v-menu>
-    <v-menu
-      location="bottom"
-      class="elelvation-1"
-      transition="scale-transition"
-    >
+    <v-menu location="bottom" class="elevation-1" transition="scale-transition">
       <template v-slot:activator="{ props }">
         <v-btn v-bind="props" variant="text">
           <v-icon icon="mdi-open-in-new" size="x-large"></v-icon>
@@ -324,17 +316,18 @@ export default {
 
     this.currentProjectID = store.state.project.project_id
     const userLocale = store.state.locale
+    const browserLocale = Util.getNavigatorLanguage()
     if (userLocale.lang && userLocale.text) {
       this.handleChangeLocale({
         value: userLocale.lang,
         text: userLocale.text,
       })
+    } else {
+      this.handleChangeLocale({
+        value: browserLocale,
+        text: this.getLocaleText(browserLocale),
+      })
     }
-    const browserLocale = Util.getNavigatorLanguage()
-    this.handleChangeLocale({
-      value: browserLocale,
-      text: this.getLocaleText(browserLocale),
-    })
   },
   methods: {
     customFilter(value, search) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -29,6 +29,7 @@ router.beforeEach(async (to, from, next) => {
     typeof user_id != 'undefined' &&
     project_id != current_project_id
   ) {
+    // Change project
     const admin = await axios
       .get('/iam/is-admin/?user_id=' + user_id)
       .catch((err) => {
@@ -46,13 +47,19 @@ router.beforeEach(async (to, from, next) => {
     if (res.data.data.project) {
       await store.commit('updateProject', res.data.data.project[0])
       let query = Object.assign({}, to.query)
-      // delete query["project_id"]
       query.project_id = store.state.project.project_id
       router.push({ query: query }) // Edit query parameter
       router.go({ path: to.currentRoute })
       next()
       return
     }
+  }
+  if (!to.query.project_id && current_project_id != '') {
+    // Force set project_id parameter
+    let query = Object.assign({}, to.query)
+    query.project_id = current_project_id
+    next({ ...to, query })
+    return
   }
   next()
 })

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -475,7 +475,7 @@
           </v-row>
 
           <v-row dense class="mx-2">
-            <v-col cols="3">
+            <v-col cols="2">
               <v-list-item two-line>
                 <v-list-item-subtitle>
                   <v-icon :color="getColorByScore(findingModel.score)"
@@ -492,7 +492,7 @@
                 </v-list-item-title>
               </v-list-item>
             </v-col>
-            <v-col cols="3">
+            <v-col cols="2">
               <v-list-item two-line>
                 <v-list-item-subtitle>
                   <v-icon>mdi-scoreboard</v-icon>
@@ -518,6 +518,32 @@
                   @click="handleRecommendItem"
                 >
                   {{ $t(`btn['Recommendation']`) }}
+                </v-btn>
+              </v-list-item-title>
+            </v-col>
+            <v-col cols="4">
+              <v-list-item-subtitle>
+                <v-icon left>mdi-gesture-tap</v-icon>
+                {{ $t(`item['Action']`) }}
+              </v-list-item-subtitle>
+              <v-list-item-title>
+                <v-btn
+                  color="red-darken-1"
+                  text
+                  variant="outlined"
+                  class="ma-1"
+                  @click="handleArchiveButtonClick"
+                >
+                  {{ $t(`btn['ARCHIVE']`) }}
+                </v-btn>
+                <v-btn
+                  color="red-darken-1"
+                  text
+                  variant="outlined"
+                  class="ma-1"
+                  @click="handlePendButtonClick"
+                >
+                  {{ $t(`btn['PEND']`) }}
                 </v-btn>
               </v-list-item-title>
             </v-col>


### PR DESCRIPTION
以下のUX変更を行います
- 言語設定は一度選択したものがユーザ設定として保持します（ブラウザの言語設定ではなくユーザ設定を優先するようにします）
- プロジェクト選択中はproject_idを常にクエリパラメータに設定して引き回します
- 生成AIの要約の表示で、縦幅が可変になってしまうことで、アーカイブボタン等の位置もズレてしまう問題があったので、アクションボタンを上の方にも持っていきました