### PR TITLE
add false positive to pending finding

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -305,6 +305,7 @@ const en = {
         'I have detected the following security issue in my cloud environment. Please summarize the contents.',
       'GenerativeAI Question-2':
         'Also, please include any ways to address the issue.',
+      'False Positive': 'Check if Finding is a false positive',
       SearchHistory: 'SearchHistory',
       PopularSearch: {
         label: {

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -303,6 +303,7 @@ const ja = {
       'GenerativeAI Question-1':
         'クラウド環境で以下のセキュリティの問題を検知しました。日本語で内容を要約してください。',
       'GenerativeAI Question-2': 'また、問題の対処方法もあれば含めてください。',
+      'False Positive': 'Findingが誤検知の場合にチェックしてください',
       SearchHistory: '検索履歴',
       PopularSearch: {
         label: {

--- a/src/mixin/api/finding.js
+++ b/src/mixin/api/finding.js
@@ -228,13 +228,14 @@ const finding = {
           return Promise.reject(err)
         })
     },
-    async putPendFinding(finding_id, note, expired_at) {
+    async putPendFinding(finding_id, note, reason, expired_at) {
       const param = {
         project_id: this.getCurrentProjectID(),
         pend_finding: {
           finding_id: finding_id,
           project_id: this.getCurrentProjectID(),
           note: note,
+          reason: reason,
         },
       }
       if (expired_at) {

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -839,6 +839,11 @@
           </span>
         </v-card-title>
         <v-card-text>
+          <v-checkbox
+            v-model="pendModel.false_positive"
+            hide-details
+            :label="$t(`view.finding['False Positive']`)"
+          ></v-checkbox>
           <v-list two-line>
             <v-list-item prepend-icon="mdi-identifier">
               <v-list-item-title v-if="pendAll">
@@ -876,13 +881,6 @@
                 :label="$t(`item['Expired At']`)"
                 :items="pendExpiredItems"
               />
-            </v-list-item>
-            <v-list-item>
-              <v-checkbox
-                v-model="pendModel.false_positive"
-                hide-details
-                :label="$t(`view.finding['False Positive']`)"
-              ></v-checkbox>
             </v-list-item>
           </v-list>
         </v-card-text>
@@ -1754,7 +1752,7 @@ export default {
     },
     async handlePendItemSubmit(isArchived) {
       this.loading = true
-      let pendReason = this.getPendReason(this.pendModel.false_positive)
+      const pendReason = this.getPendReason(this.pendModel.false_positive)
       await this.putPendFinding(
         this.findingModel.finding_id,
         this.pendModel.note,
@@ -1783,7 +1781,7 @@ export default {
     async handlePendSelectedSubmit(isArchived) {
       this.loading = true
       const count = this.table.selected.length
-      let pendReason = this.getPendReason(this.pendModel.false_positive)
+      const pendReason = this.getPendReason(this.pendModel.false_positive)
       this.table.selected.forEach(async (item) => {
         if (!item.finding_id) return
         await this.putPendFinding(

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -877,6 +877,13 @@
                 :items="pendExpiredItems"
               />
             </v-list-item>
+            <v-list-item>
+              <v-checkbox
+                v-model="pendModel.false_positive"
+                hide-details
+                :label="$t(`view.finding['False Positive']`)"
+              ></v-checkbox>
+            </v-list-item>
           </v-list>
         </v-card-text>
         <v-card-actions>
@@ -1154,6 +1161,7 @@ export default {
         finding_id: '',
         note: '',
         expired_at: '',
+        false_positive: false,
       },
       pendExpiredItems: [
         '3 days',
@@ -1746,9 +1754,11 @@ export default {
     },
     async handlePendItemSubmit(isArchived) {
       this.loading = true
+      let pendReason = this.getPendReason(this.pendModel.false_positive)
       await this.putPendFinding(
         this.findingModel.finding_id,
         this.pendModel.note,
+        pendReason,
         this.getPendExpiredSecound(this.pendModel.expired_at)
       )
       if (isArchived) {
@@ -1773,11 +1783,13 @@ export default {
     async handlePendSelectedSubmit(isArchived) {
       this.loading = true
       const count = this.table.selected.length
+      let pendReason = this.getPendReason(this.pendModel.false_positive)
       this.table.selected.forEach(async (item) => {
         if (!item.finding_id) return
         await this.putPendFinding(
           item.finding_id,
           this.pendModel.note,
+          pendReason,
           this.getPendExpiredSecound(this.pendModel.expired_at)
         )
       })
@@ -1806,7 +1818,12 @@ export default {
           return null
       }
     },
-
+    getPendReason(false_positive) {
+      if (false_positive) {
+        return 1
+      }
+      return 0
+    },
     async handleRecommendItem() {
       this.recommendDialog = true
     },


### PR DESCRIPTION
pend findingに誤検知かどうかのFBを受けるためのチェックボックスを追加します
coreやDBでは、reasonとしてENUMで受けますが現状では誤検知以外の判定がないためチェックボックスにしてます
今後、用途が増えるタイミングでセレクトボックスにしたりするのもありかなと思います

![image](https://github.com/ca-risken/web/assets/35591487/b1cf34ec-5ee7-44f4-a6f7-23620ff8cca8)
