### PR TITLE
fix: codescan setting

### DIFF
--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -121,9 +121,6 @@
                   </scan-status>
                   <v-chip variant="flat" color="grey" v-else> Disabled </v-chip>
                 </template>
-                <template v-slot:[`item.updated_at`]="{ item }">
-                  <v-chip>{{ formatTime(item.value.updated_at) }}</v-chip>
-                </template>
                 <template v-slot:[`item.action`]="{ item }">
                   <v-menu>
                     <template v-slot:activator="{ props }">
@@ -391,12 +388,6 @@ export default {
           align: 'start',
           sortable: true,
           key: 'status_code_scan',
-        },
-        {
-          title: this.$i18n.t('item["Updated"]'),
-          align: 'start',
-          sortable: true,
-          key: 'updated_at',
         },
         {
           title: this.$i18n.t('item["Action"]'),

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -837,7 +837,7 @@
                       variant="outlined"
                       color="blue-darken-1"
                       @click="handleCodeScanEditSubmit"
-                      :disabled="!isConfiguredCodeScanSetting"
+                      :disabled="!isConfiguredGitHubSetting"
                       :loading="loading"
                       v-else
                       >{{ $t(`btn['SAVE']`) }}
@@ -1310,8 +1310,7 @@ export default {
       if (dependencySetting) {
         this.dependencySetting = dependencySetting
       }
-      this.$emit('edit-notify', 'Success: Updated.')
-      this.$emit('closeDialog')
+      this.e6 = 4
     },
     async handleCodeScanEditSubmit() {
       if (this.isEnabledCodeScan && !this.$refs.formCodeScan.validate()) {
@@ -1331,7 +1330,8 @@ export default {
       if (codeScanSetting) {
         this.codeScanSetting = codeScanSetting
       }
-      this.e6 = 3
+      this.$emit('edit-notify', 'Success: Updated.')
+      this.$emit('closeDialog')
     },
 
     async handleScanGitleaks(fullscan) {


### PR DESCRIPTION
CodeScan設定にたどり着けないバグを修正します。
また、一覧の項目が多く、右端のアクションが横スクロールしないとみれなくなっているため更新日時を非表示にします