### PR TITLE
fix: default false positive flg

### DIFF
--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1739,11 +1739,13 @@ export default {
     handleArchiveButtonClick() {
       this.pendAll = false
       this.isArchived = true
+      this.pendModel.false_positive = false
       this.pendDialog = true
     },
     handlePendButtonClick() {
       this.pendAll = false
       this.isArchived = false
+      this.pendModel.false_positive = false
       this.pendDialog = true
     },
     handleArchiveItem(row) {


### PR DESCRIPTION
false positiveの✅が一度押して再度開き直すと✅済みになってしまうので、修正します