### PR TITLE
Fix first alert firstviewed

### DIFF
--- a/src/mixin/api/alert.js
+++ b/src/mixin/api/alert.js
@@ -60,10 +60,9 @@ const alert = {
       })
     },
 
-    async putAlertFirstViewedAt(project_id, alert_id) {
+    async putAlertFirstViewedAt(project_id) {
       const param = {
         project_id: project_id,
-        alert_id: alert_id,
       }
       await this.$axios
         .post('/alert/put-alert-first-viewed-at/', param)

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -651,24 +651,24 @@ let mixin = {
       if (query.project_id && query.project_id != '') {
         project_id = parseInt(query.project_id)
       }
-      let userID
+      let user_id
       if (store.state && store.state.user && store.state.user.user_id) {
-        userID = store.state.user.user_id
+        user_id = store.state.user.user_id
       } else {
-        userID = await this.signin()
+        user_id = await this.signin()
       }
-      if (!userID) {
+      if (!user_id) {
         return
       }
-      const userInProject = await this.UserInProject(project_id)
+      const userInProject = await this.UserInProject(project_id,user_id)
       if (project_id === 0 || !userInProject) {
         return
       }
-      await this.putAlertFirstViewedAt(project_id)
+      await this.putAlertFirstViewedAt(project_id, user_id)
       return
     },
-    async UserInProject(project_id) {
-      const searchCond = '&project_id=' + project_id
+    async UserInProject(project_id,user_id) {
+      const searchCond = '&project_id=' + project_id + '&user_id=' + user_id
       const userIDs = await this.listUserAPI(searchCond).catch((err) => {
         return Promise.reject(err)
       })

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -647,20 +647,16 @@ let mixin = {
       if (!this.$route.query) return
       const query = this.$route.query
       let project_id = 0
-      let alert_id = 0
       if (query.project_id && query.project_id != '') {
         project_id = parseInt(query.project_id)
       }
-      if (query.alert_id && query.alert_id != '') {
-        alert_id = parseInt(query.alert_id)
-      }
       let userInProject = false
-      if (store.state && store.state.user && store.state.user.user_id ){
+      if (store.state && store.state.user && store.state.user.user_id) {
         userInProject = await this.UserInProject(project_id)
         if (project_id === 0 || !userInProject) {
           return
         }
-        await this.putAlertFirstViewedAt(project_id, alert_id)
+        await this.putAlertFirstViewedAt(project_id)
         return
       }
       await setTimeout(async () => {
@@ -668,7 +664,7 @@ let mixin = {
         if (project_id === 0 || !userInProject) {
           return
         }
-        await this.putAlertFirstViewedAt(project_id, alert_id)
+        await this.putAlertFirstViewedAt(project_id)
       }, 3000)
     },
     async UserInProject(project_id) {

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -654,10 +654,29 @@ let mixin = {
       if (query.alert_id && query.alert_id != '') {
         alert_id = parseInt(query.alert_id)
       }
-      if (project_id === 0 || alert_id === 0) {
+      const userInProject = await this.UserInProject(project_id)
+      if (project_id === 0 || !userInProject) {
         return
       }
       await this.putAlertFirstViewedAt(project_id, alert_id)
+    },
+    async UserInProject(project_id) {
+      console.log(await this.$store.state.user)
+      const user = this.$store.state.user
+      if (!user || !user.user_id) {
+        return false
+      }
+      const searchCond = '&project_id=' + project_id
+      const userIDs = await this.listUserAPI(searchCond).catch((err) => {
+        return Promise.reject(err)
+      })
+      if (!userIDs) {
+        return false
+      }
+      if (userIDs.includes(user.user_id)) {
+        return true
+      }
+      return false
     },
   },
 }

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -660,14 +660,14 @@ let mixin = {
       if (!user_id) {
         return
       }
-      const userInProject = await this.UserInProject(project_id,user_id)
+      const userInProject = await this.UserInProject(project_id, user_id)
       if (project_id === 0 || !userInProject) {
         return
       }
       await this.putAlertFirstViewedAt(project_id, user_id)
       return
     },
-    async UserInProject(project_id,user_id) {
+    async UserInProject(project_id, user_id) {
       const searchCond = '&project_id=' + project_id + '&user_id=' + user_id
       const userIDs = await this.listUserAPI(searchCond).catch((err) => {
         return Promise.reject(err)

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -654,23 +654,25 @@ let mixin = {
       if (query.alert_id && query.alert_id != '') {
         alert_id = parseInt(query.alert_id)
       }
-      const userInProject = await this.UserInProject(project_id)
-      if (project_id === 0 || !userInProject) {
-        return
-      }
-      await this.putAlertFirstViewedAt(project_id, alert_id)
+      let userInProject = false
+      await setTimeout(async () => {
+        userInProject = await this.UserInProject(project_id)
+        if (project_id === 0 || !userInProject) {
+          return
+        }
+        await this.putAlertFirstViewedAt(project_id, alert_id)
+      }, 3000)
     },
     async UserInProject(project_id) {
-      console.log(await this.$store.state.user)
-      const user = this.$store.state.user
-      if (!user || !user.user_id) {
-        return false
-      }
       const searchCond = '&project_id=' + project_id
       const userIDs = await this.listUserAPI(searchCond).catch((err) => {
         return Promise.reject(err)
       })
       if (!userIDs) {
+        return false
+      }
+      const user = store.state.user
+      if (!user || !user.user_id) {
         return false
       }
       if (userIDs.includes(user.user_id)) {

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -655,6 +655,14 @@ let mixin = {
         alert_id = parseInt(query.alert_id)
       }
       let userInProject = false
+      if (store.state && store.state.user && store.state.user.user_id ){
+        userInProject = await this.UserInProject(project_id)
+        if (project_id === 0 || !userInProject) {
+          return
+        }
+        await this.putAlertFirstViewedAt(project_id, alert_id)
+        return
+      }
       await setTimeout(async () => {
         userInProject = await this.UserInProject(project_id)
         if (project_id === 0 || !userInProject) {

--- a/src/view/alert/Alert.vue
+++ b/src/view/alert/Alert.vue
@@ -308,11 +308,12 @@
 import mixin from '@/mixin'
 import alert from '@/mixin/api/alert'
 import finding from '@/mixin/api/finding'
+import iam from '@/mixin/api/iam'
 import BottomSnackBar from '@/component/widget/snackbar/BottomSnackBar.vue'
 import { VDataTable } from 'vuetify/labs/VDataTable'
 export default {
   name: 'AlertList',
-  mixins: [mixin, alert, finding],
+  mixins: [mixin, alert, finding, iam],
   components: {
     BottomSnackBar,
     VDataTable,

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1091,6 +1091,7 @@ import Util from '@/util'
 import store from '@/store'
 import finding from '@/mixin/api/finding'
 import alert from '@/mixin/api/alert'
+import iam from '@/mixin/api/iam'
 import BottomSnackBar from '@/component/widget/snackbar/BottomSnackBar.vue'
 import ClipBoard from '@/component/widget/clipboard/ClipBoard.vue'
 import JsonViewer from 'vue-json-viewer'
@@ -1101,7 +1102,7 @@ import 'highlight.js/styles/monokai.css'
 
 export default {
   name: 'FindingList',
-  mixins: [mixin, finding, alert],
+  mixins: [mixin, finding, alert, iam],
   components: {
     BottomSnackBar,
     ClipBoard,


### PR DESCRIPTION
プロジェクトに属するユーザーがFinding,Alert画面を閲覧した時にのみFirstAlertViewedAtを更新するように修正します
新規にRISKEN画面を開いた際にはuser_idを一時的に取得できないタイミングがあるため、以下の挙動にしました
- ロード済みで画面遷移時
ListUserを行った後、取得した結果にstoreから取得したuser_idが存在するか確認
存在する場合、FirstAlertViewedAtを更新
- ロード済みでなく、画面を開いた際(リンクから直接Alert、Finding画面に飛んだ場合など)
画面ロード時のsigninUserが完了するのを待つため、3秒待つ
その後、ListUserを実施し、取得した結果にstoreから取得したuser_idが存在するか確認
存在する場合、FirstAlertViewedAtを更新

#### user_idを一時的に取得できないタイミング
AppToolbar.vueでのマウント時の処理に、[ await this.signinUser()](https://github.com/ca-risken/web/blob/master/src/component/AppToolbar.vue#L302)が存在する
この関数内で、一旦storeのuserを削除しsignin、getUserを実行後に取得し直したuserをstoreに格納する
この処理の間、storeのuserが存在しない状態となりuser_idが取得できない