### PR TITLE
preserves the state of pend finding

### DIFF
--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1431,7 +1431,7 @@ export default {
           finding_id: id,
           pend_user_id: pend.pend_user_id ? pend.pend_user_id : 0,
           note: pend.note ? pend.note : '',
-          expired_at: pend.expired_at ? pend.expired_at : 0,
+          expired_at: pend.expired_at ? pend.expired_at : null,
           false_positive: pend.false_positive,
         },
       }
@@ -1820,6 +1820,11 @@ export default {
       this.finishSuccess('Success: Pend ' + count + ' findings.')
     },
     getPendExpiredSecound(expiredAt) {
+      const parsedDate = Date.parse(expiredAt)
+      if (!isNaN(parsedDate)) {
+        console.log(parsedDate)
+        return parsedDate / 1000
+      }
       const nowUnix = Math.floor(Date.now() / 1000)
       const oneDaySec = 86400
       switch (expiredAt) {
@@ -2105,11 +2110,15 @@ export default {
       this.aiFetchController.abort() // Abort the fetch request
     },
     assignPendModel() {
+      let expired_at = null
+      if (this.findingModel.pendModel.expired_at) {
+        expired_at = this.formatTime(this.findingModel.pendModel.expired_at)
+      }
       this.pendModel = {
         finding_id: this.findingModel.finding_id,
         pend_user_id: this.findingModel.pendModel.pend_user_id,
         note: this.findingModel.pendModel.note,
-        expired_at: this.findingModel.pendModel.expired_at,
+        expired_at: expired_at,
       }
     },
 

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1755,7 +1755,6 @@ export default {
       this.pendModel.false_positive = false
       this.assignPendModel()
       this.pendDialog = true
-      console.log(this.pendModel)
     },
     handleArchiveItem(row) {
       this.findingModel = Object.assign(this.findingModel, row.value)
@@ -1822,7 +1821,6 @@ export default {
     getPendExpiredSecound(expiredAt) {
       const parsedDate = Date.parse(expiredAt)
       if (!isNaN(parsedDate)) {
-        console.log(parsedDate)
         return parsedDate / 1000
       }
       const nowUnix = Math.floor(Date.now() / 1000)


### PR DESCRIPTION
Archive,PendされたFindingを再度更新する際に登録済みのデータがフォームに反映されない問題の修正
loadItem時のfindingごとのpendされたデータの持ち方を変更し、pendDialogを開く前に登録済みデータをフォームで使用するモデルに設定されるようにしました
また、登録されているデータにexpired_atが設定されている場合にはフォームにその日付が入るようになっています。そのため、日付の文字列が入った状態でPendボタンを押した際には日付をunixtimestampに変換する処理を追加しました。
複数のFindingをまとめてArchive,Pendする際には既存のデータが反映されるようにはしていません。