### PR TITLE
display pend user name

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -159,6 +159,7 @@ const en = {
     'OSINT ID': 'OSINT ID',
     'OSINT Relation ID': 'OSINT Reration ID',
     Passed: 'Passed',
+    'Pend By': 'Pend By',
     PersonalAccessToken: 'PersonalAccessToken',
     Policies: 'Policies',
     'Policy Name': 'Policy Name',

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -159,7 +159,7 @@ const en = {
     'OSINT ID': 'OSINT ID',
     'OSINT Relation ID': 'OSINT Reration ID',
     Passed: 'Passed',
-    'Pend By': 'Pend By',
+    'Archived By': 'Archived By',
     PersonalAccessToken: 'PersonalAccessToken',
     Policies: 'Policies',
     'Policy Name': 'Policy Name',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -159,7 +159,7 @@ const ja = {
     'OSINT ID': 'OSINT ID',
     'OSINT Relation ID': 'OSINT関連ID',
     Passed: '経過日数',
-    'Pend By': 'Pendしたユーザー',
+    'Archived By': 'Archiveしたユーザー',
     PersonalAccessToken: 'パーソナルアクセストークン',
     Policies: 'ポリシー設定',
     'Policy Name': 'ポリシー名',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -159,6 +159,7 @@ const ja = {
     'OSINT ID': 'OSINT ID',
     'OSINT Relation ID': 'OSINT関連ID',
     Passed: '経過日数',
+    'Pend By': 'Pendしたユーザー',
     PersonalAccessToken: 'パーソナルアクセストークン',
     Policies: 'ポリシー設定',
     'Policy Name': 'ポリシー名',

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -572,7 +572,7 @@
               <v-col v-if="findingModel.pendModel.pend_user" cols="2">
                 <v-list-item-subtitle>
                   <v-icon left>mdi-account-outline</v-icon>
-                  {{ $t(`item['Pend By']`) }}
+                  {{ $t(`item['Archived By']`) }}
                 </v-list-item-subtitle>
                 <v-list-item-title class="mt-4" align="center">
                   <v-chip>{{ findingModel.pendModel.pend_user }}</v-chip>

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -569,11 +569,16 @@
                   </v-alert>
                 </v-list-item-title>
               </v-col>
-              <v-col
-                v-if="findingModel.pendModel.expired_at != 0"
-                cols="3"
-                class="mx-4"
-              >
+              <v-col v-if="findingModel.pendModel.pend_user" cols="2">
+                <v-list-item-subtitle>
+                  <v-icon left>mdi-account-outline</v-icon>
+                  {{ $t(`item['Pend By']`) }}
+                </v-list-item-subtitle>
+                <v-list-item-title class="mt-4" align="center">
+                  <v-chip>{{ findingModel.pendModel.pend_user }}</v-chip>
+                </v-list-item-title>
+              </v-col>
+              <v-col v-if="findingModel.pendModel.expired_at" cols="2">
                 <v-list-item-subtitle>
                   <v-icon left>mdi-clock-outline</v-icon>
                   {{ $t(`item['Expired At']`) }}
@@ -1430,6 +1435,9 @@ export default {
         pendModel: {
           finding_id: id,
           pend_user_id: pend.pend_user_id ? pend.pend_user_id : 0,
+          pend_user: pend.pend_user_id
+            ? await this.getPendUser(pend.pend_user_id)
+            : '',
           note: pend.note ? pend.note : '',
           expired_at: pend.expired_at ? pend.expired_at : null,
           false_positive: pend.false_positive,
@@ -2118,6 +2126,10 @@ export default {
         note: this.findingModel.pendModel.note,
         expired_at: expired_at,
       }
+    },
+    async getPendUser(userID) {
+      const user = await this.getUserAPI(userID)
+      return user.name
     },
 
     // finish


### PR DESCRIPTION
findingの詳細モーダルにて、Pendしたユーザーの名前を表示するように修正します(空の場合表示なし)
また、フォーマットを整えるためにcols、classの値を修正
PendFindingのExpiredAtが空の時にチップを表示しないようにしました
=> 元々空の場合や0値の場合には表示しないようにしていたが、(おそらく)前回の変更で0値で表示されるようになってしまっていたため
![image](https://github.com/ca-risken/web/assets/35591487/7e076823-8837-4f3c-92ab-4ff1846de340)
