### PR TITLE
fix: no project user error

### DIFF
--- a/src/axios/index.js
+++ b/src/axios/index.js
@@ -46,18 +46,18 @@ axios.interceptors.response.use(
     const status = error.response.status
     if (status === 303) {
       console.log('303')
-      router.push({ path: '/' })
+      router.push({ path: '/', query: router.currentRoute.value.query })
     } else if (status === 401) {
       console.log('401 Authn error')
       router.push({
         path: '/iam/profile',
-        query: { url: router.currentRoute.value.fullPath },
+        query: router.currentRoute.value.query,
       })
     } else if (status === 403) {
       console.log('403 Authz error')
       router.push({
         path: '/403',
-        query: { url: router.currentRoute.value.fullPath },
+        query: router.currentRoute.value.query,
       })
     }
     return Promise.reject(error)

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -269,6 +269,9 @@ const en = {
     'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.':
       'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.',
     'Sorry, page not found': 'Sorry, page not found',
+    'Project not selected.': 'Project not selected.',
+    'Click 🅿 on the menu bar on the screen and select a project.':
+      'Click 🅿 on the menu bar on the screen and select a project.',
   },
   view: {
     dashboard: {

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -269,9 +269,6 @@ const en = {
     'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.':
       'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.',
     'Sorry, page not found': 'Sorry, page not found',
-    'Project not selected.': 'Project not selected.',
-    'Click 🅿 on the menu bar on the screen and select a project.':
-      'Click 🅿 on the menu bar on the screen and select a project.',
   },
   view: {
     dashboard: {

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -269,6 +269,8 @@ const en = {
     'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.':
       'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.',
     'Sorry, page not found': 'Sorry, page not found',
+    'Project not selected. Click [P] on the menu bar on the screen and select a project.':
+      'Project not selected. Click [P] on the menu bar on the screen and select a project.',
   },
   view: {
     dashboard: {

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -269,6 +269,9 @@ const ja = {
     'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.':
       '申し訳ありません。このプロジェクトへのアクセスが拒否されたか、セッションが期限切れです。\n アクセスが必要な場合には管理者にアクセス権をリクエストしてください。',
     'Sorry, page not found': 'ページが見つかりませんでした。',
+    'Project not selected.': 'プロジェクトが未選択です。',
+    'Click 🅿 on the menu bar on the screen and select a project.':
+      '画面上のメニューバーから🅿ボタンをクリックし、プロジェクトを選択してください。',
   },
   view: {
     dashboard: {

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -269,9 +269,6 @@ const ja = {
     'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.':
       '申し訳ありません。このプロジェクトへのアクセスが拒否されたか、セッションが期限切れです。\n アクセスが必要な場合には管理者にアクセス権をリクエストしてください。',
     'Sorry, page not found': 'ページが見つかりませんでした。',
-    'Project not selected.': 'プロジェクトが未選択です。',
-    'Click 🅿 on the menu bar on the screen and select a project.':
-      '画面上のメニューバーから🅿ボタンをクリックし、プロジェクトを選択してください。',
   },
   view: {
     dashboard: {

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -269,6 +269,8 @@ const ja = {
     'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.':
       '申し訳ありません。このプロジェクトへのアクセスが拒否されたか、セッションが期限切れです。\n アクセスが必要な場合には管理者にアクセス権をリクエストしてください。',
     'Sorry, page not found': 'ページが見つかりませんでした。',
+    'Project not selected. Click [P] on the menu bar on the screen and select a project.':
+      'プロジェクトが未選択です。画面上のメニューバーから[P]をクリックし、プロジェクトを選択してください。',
   },
   view: {
     dashboard: {

--- a/src/mixin/api/alert.js
+++ b/src/mixin/api/alert.js
@@ -275,9 +275,9 @@ const alert = {
         })
     },
 
-    async requestProjectRoleAlertNotification(user_id) {
+    async requestProjectRoleAlertNotification(user_id, project_id) {
       const param = {
-        project_id: this.getCurrentProjectID(),
+        project_id: project_id,
         user_id: user_id,
       }
       await this.$axios

--- a/src/view/error/Deny.vue
+++ b/src/view/error/Deny.vue
@@ -4,22 +4,11 @@
       <div class="text-md-center">
         <h1>403</h1>
         <h2 class="my-3 text-h5" style="white-space: pre-line">
-          <div v-if="noProject">
-            {{ $t(`error['Project not selected.']`) }}
-            <br />
-            {{
-              $t(
-                `error['Click 🅿 on the menu bar on the screen and select a project.']`
-              )
-            }}
-          </div>
-          <div v-else>
-            {{
-              $t(
-                `error['Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.']`
-              )
-            }}
-          </div>
+          {{
+            $t(
+              `error['Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.']`
+            )
+          }}
         </h2>
       </div>
       <div class="text-md-center">
@@ -54,12 +43,6 @@ export default {
   data() {
     return {
       loading: false,
-      noProject: false,
-    }
-  },
-  mounted() {
-    if (!this.$store.state.project.project_id) {
-      this.noProject = true
     }
   },
   methods: {
@@ -69,8 +52,10 @@ export default {
     },
 
     async submitRequest() {
+      const project_id = Number(this.$route.query.project_id)
       await this.requestProjectRoleAlertNotification(
-        store.state.user.user_id
+        store.state.user.user_id,
+        project_id
       ).catch((err) => {
         this.finishError(err.response.data)
         return Promise.reject(err)

--- a/src/view/error/Deny.vue
+++ b/src/view/error/Deny.vue
@@ -4,11 +4,22 @@
       <div class="text-md-center">
         <h1>403</h1>
         <h2 class="my-3 text-h5" style="white-space: pre-line">
-          {{
-            $t(
-              `error['Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.']`
-            )
-          }}
+          <div v-if="noProject">
+            {{ $t(`error['Project not selected.']`) }}
+            <br />
+            {{
+              $t(
+                `error['Click 🅿 on the menu bar on the screen and select a project.']`
+              )
+            }}
+          </div>
+          <div v-else>
+            {{
+              $t(
+                `error['Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.']`
+              )
+            }}
+          </div>
         </h2>
       </div>
       <div class="text-md-center">
@@ -43,6 +54,12 @@ export default {
   data() {
     return {
       loading: false,
+      noProject: false,
+    }
+  },
+  mounted() {
+    if (!this.$store.state.project.project_id) {
+      this.noProject = true
     }
   },
   methods: {

--- a/src/view/error/Deny.vue
+++ b/src/view/error/Deny.vue
@@ -52,7 +52,20 @@ export default {
     },
 
     async submitRequest() {
-      const project_id = Number(this.$route.query.project_id)
+      let project_id = undefined
+      if (this.$route.query.project_id) {
+        project_id = Number(this.$route.query.project_id)
+      } else if (this.$store.state.project.project_id) {
+        project_id = this.$store.state.project.project_id
+      }
+      if (!project_id) {
+        this.finishError(
+          this.$t(
+            `error['Project not selected. Click [P] on the menu bar on the screen and select a project.']`
+          )
+        )
+        return
+      }
       await this.requestProjectRoleAlertNotification(
         store.state.user.user_id,
         project_id


### PR DESCRIPTION
403画面の権限申請のボタンですが、クエリパラメータのproject_idで申請を出すようにします。
今まではLocalStorageのプロジェクトを取ってくる実装になっていたので、ここが目的とずれてる実装になってそうでした。
また、初めてRISKENにアクセスする人はLocalStorageにプロジェクト情報をもってないので、project_idがブランクになります。