### PR TITLE
fix: resign

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -271,8 +271,8 @@ const en = {
   error: {
     'Sorry, Please access again after a while.':
       'Sorry, The server is under heavy load... Please access again after a while.',
-    'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.':
-      'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.',
+    'Session expired. Please return to the HOME screen and try accessing again. If this is your first time accessing the project, please REQUEST PROJECT ROLE with the administrator.':
+      'Session expired. Please return to the HOME screen and try accessing again.\n If this is your first time accessing the project, please `REQUEST PROJECT ROLE` from the administrator.',
     'Sorry, page not found': 'Sorry, page not found',
     'Project not selected. Click [P] on the menu bar on the screen and select a project.':
       'Project not selected. Click [P] on the menu bar on the screen and select a project.',
@@ -333,6 +333,7 @@ const en = {
         },
         tooltip: {
           ALL: 'Search all Findings',
+          Azure: 'Search for Azure-related Findings',
           HighScore: 'Search high scores Findings',
           AWS: 'Search for AWS-related Findings',
           GCP: 'Search for GCP-related Findings',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -271,8 +271,8 @@ const ja = {
   error: {
     'Sorry, Please access again after a while.':
       '申し訳ありません。しばらく経ってからアクセスしてください。',
-    'Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.':
-      '申し訳ありません。このプロジェクトへのアクセスが拒否されたか、セッションが期限切れです。\n アクセスが必要な場合には管理者にアクセス権をリクエストしてください。',
+    'Session expired. Please return to the HOME screen and try accessing again. If this is your first time accessing the project, please REQUEST PROJECT ROLE with the administrator.':
+      'セッションが切れました。ホーム画面へ戻って再度アクセスしてください。\nもし、初めてプロジェクトにアクセスする場合は、管理者に権限をリクエストしてください。',
     'Sorry, page not found': 'ページが見つかりませんでした。',
     'Project not selected. Click [P] on the menu bar on the screen and select a project.':
       'プロジェクトが未選択です。画面上のメニューバーから[P]をクリックし、プロジェクトを選択してください。',
@@ -332,6 +332,7 @@ const ja = {
         },
         tooltip: {
           ALL: '全てのFindingを検索します',
+          Azure: 'Azure関連のFindingを検索します',
           HighScore: '高スコアを検索します',
           AWS: 'AWS関連のFindingを検索します',
           GCP: 'GCP関連のFindingを検索します',

--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -189,6 +189,15 @@ let mixin = {
       await this.signoutAPI()
       this.$router.push('/auth/signin/')
     },
+    async reSign() {
+      const xsrfToken = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('XSRF-TOKEN='))
+      if (xsrfToken) {
+        return Promise.resolve()
+      }
+      return this.signinUser()
+    },
     reload: function () {
       this.$router.go({
         path: this.$router.currentRoute.value.path,

--- a/src/view/Dashboard.vue
+++ b/src/view/Dashboard.vue
@@ -140,13 +140,12 @@ import mixin from '@/mixin'
 import finding from '@/mixin/api/finding'
 import alert from '@/mixin/api/alert'
 import iam from '@/mixin/api/iam'
-import signin from '@/mixin/api/signin'
 import StatusStatistic from '@/component/widget/statistic/StatusStatistic.vue'
 import MiniStatistic from '@/component/widget/statistic/MiniStatistic.vue'
 import CategoryStatistic from '@/component/widget/statistic/CategoryStatistic.vue'
 export default {
   name: 'PageDashboard',
-  mixins: [mixin, finding, alert, iam, signin],
+  mixins: [mixin, finding, alert, iam],
   components: {
     StatusStatistic,
     MiniStatistic,
@@ -221,7 +220,6 @@ export default {
     }
   },
   async mounted() {
-    await this.signinUser()
     if (!this.$store.state.project.project_id) {
       return false
     }

--- a/src/view/Home.vue
+++ b/src/view/Home.vue
@@ -1,13 +1,16 @@
 <template><div /></template>
 <script>
 import mixin from '@/mixin'
+import signin from '@/mixin/api/signin'
+import iam from '@/mixin/api/iam'
 
 export default {
   name: 'AppHome',
-  mounted() {
+  async mounted() {
+    await this.reSign()
     this.redirectDashBoard()
   },
-  mixins: [mixin],
+  mixins: [mixin, signin, iam],
   methods: {
     async redirectDashBoard() {
       this.$router.push('/dashboard')

--- a/src/view/alert/Alert.vue
+++ b/src/view/alert/Alert.vue
@@ -400,7 +400,8 @@ export default {
       ]
     },
   },
-  mounted() {
+  async mounted() {
+    await this.reSign()
     this.UpdateAlertFirstViewedAt()
     this.handleRefleshList()
   },
@@ -554,8 +555,6 @@ export default {
       this.alertModel = {}
       this.alertModel = Object.assign(this.alertModel, item.value)
     },
-
-    // finish
 
     // finish process
     async finishSuccess(msg) {

--- a/src/view/error/Deny.vue
+++ b/src/view/error/Deny.vue
@@ -6,23 +6,27 @@
         <h2 class="my-3 text-h5" style="white-space: pre-line">
           {{
             $t(
-              `error['Sorry, access denied or time out your session... Please request access rights to the administrator if necessary.']`
+              `error['Session expired. Please return to the HOME screen and try accessing again. If this is your first time accessing the project, please REQUEST PROJECT ROLE with the administrator.']`
             )
           }}
         </h2>
       </div>
       <div class="text-md-center">
-        <v-btn
-          class="mt-3"
-          color="blue-darken-1"
-          @click="requestProjectRole"
-          :loading="loading"
-          >{{ $t(`btn['REQUEST PROJECT ROLE']`) }}</v-btn
-        >
-        <v-spacer></v-spacer>
-        <v-btn class="mt-3" color="primary" @click="goHome">{{
-          $t(`btn['HOME']`)
-        }}</v-btn>
+        <div>
+          <v-btn class="mt-3" color="primary" @click="goHome">{{
+            $t(`btn['HOME']`)
+          }}</v-btn>
+        </div>
+        <div>
+          <v-btn
+            class="mt-3"
+            color="blue-darken-1"
+            @click="requestProjectRole"
+            :loading="loading"
+            >{{ $t(`btn['REQUEST PROJECT ROLE']`) }}</v-btn
+          >
+        </div>
+        <v-spacer />
       </div>
     </v-container>
     <bottom-snack-bar ref="snackbar" />

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1429,19 +1429,16 @@ export default {
     },
   },
   async mounted() {
-    try {
-      this.isInitializing = true
-      await this.reSign()
-      this.findingHistory = this.getSearchHistory()
-      await Promise.all([
-        this.UpdateAlertFirstViewedAt(),
-        this.getTag(),
-        this.listResourceNameForCombobox(),
-      ])
-      await this.refleshList(true)
-    } finally {
-      this.isInitializing = false
-    }
+    this.isInitializing = true
+    await this.reSign()
+    this.findingHistory = this.getSearchHistory()
+    await Promise.all([
+      this.UpdateAlertFirstViewedAt(),
+      this.getTag(),
+      this.listResourceNameForCombobox(),
+    ])
+    await this.refleshList(true)
+    this.isInitializing = false
   },
   methods: {
     async refleshList(parse) {

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1136,6 +1136,7 @@ import store from '@/store'
 import finding from '@/mixin/api/finding'
 import alert from '@/mixin/api/alert'
 import iam from '@/mixin/api/iam'
+import signin from '@/mixin/api/signin'
 import BottomSnackBar from '@/component/widget/snackbar/BottomSnackBar.vue'
 import ClipBoard from '@/component/widget/clipboard/ClipBoard.vue'
 import JsonViewer from 'vue-json-viewer'
@@ -1146,7 +1147,7 @@ import 'highlight.js/styles/monokai.css'
 
 export default {
   name: 'FindingList',
-  mixins: [mixin, finding, alert, iam],
+  mixins: [mixin, finding, alert, iam, signin],
   components: {
     BottomSnackBar,
     ClipBoard,
@@ -1319,6 +1320,7 @@ export default {
       aiAnswer: '',
       aiFetchProgress: false,
       aiFetchController: new AbortController(),
+      isInitializing: true,
     }
   },
   filters: {},
@@ -1427,19 +1429,30 @@ export default {
     },
   },
   async mounted() {
-    this.UpdateAlertFirstViewedAt()
-    this.findingHistory = this.getSearchHistory()
-    this.getTag()
-    this.listResourceNameForCombobox()
-    this.refleshList(true)
+    try {
+      this.isInitializing = true
+      await this.reSign()
+      this.findingHistory = this.getSearchHistory()
+      await Promise.all([
+        this.UpdateAlertFirstViewedAt(),
+        this.getTag(),
+        this.listResourceNameForCombobox(),
+      ])
+      await this.refleshList(true)
+    } finally {
+      this.isInitializing = false
+    }
   },
   methods: {
-    refleshList(parse) {
+    async refleshList(parse) {
       this.table.options.page = 1
       this.table.total = 0
-      this.loadList(parse)
+      await this.loadList(parse)
     },
     updateOptions(options) {
+      if (this.isInitializing) {
+        return
+      }
       this.table.options.page = options.page
       this.table.options.itemsPerPage = options.itemsPerPage
       this.loadList(true)


### PR DESCRIPTION
XSRF-TOKENのセッションが切れた場合でも403エラー画面に遷移しますが、そこを考慮してUXを少し変更します。
- エラー画面の文言とボタンの位置を入れ替え
  - まず、セッションが切れた場合にホームに戻ることを推奨する
  - 続いて、「初めてアクセスする場合」の取るべき行動を提示する
- RISKENに直リンクでアクセスされる以下の画面には、最初にreSign処理を追加
  - Finding
  - Alert