### PR TITLE
add: is admin

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -255,7 +255,7 @@ const en = {
     'View Finding': 'View Finding',
     'View Item': 'View Item',
     'Test Notification': 'Test Notification',
-    Disable: 'Disable',
+    'Disable Admin': 'Disable Admin',
   },
   message: {
     'Do you really want to delete this?': 'Do you really want to delete this?',
@@ -268,8 +268,7 @@ const en = {
     'Do you want to send a test notification?':
       'Do you want to send a test notification?',
     'REQUEST PROJECT ROLE COMPLETED': 'REQUEST PROJECT ROLE COMPLETED',
-    'Do you want to disable system admin?':
-      'Do you want to disable system admin?',
+    'Do you want to disable admin?': 'Do you want to disable admin?',
   },
   error: {
     'Sorry, Please access again after a while.':

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -255,6 +255,7 @@ const en = {
     'View Finding': 'View Finding',
     'View Item': 'View Item',
     'Test Notification': 'Test Notification',
+    Disable: 'Disable',
   },
   message: {
     'Do you really want to delete this?': 'Do you really want to delete this?',
@@ -267,6 +268,8 @@ const en = {
     'Do you want to send a test notification?':
       'Do you want to send a test notification?',
     'REQUEST PROJECT ROLE COMPLETED': 'REQUEST PROJECT ROLE COMPLETED',
+    'Do you want to disable system admin?':
+      'Do you want to disable system admin?',
   },
   error: {
     'Sorry, Please access again after a while.':

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -255,7 +255,7 @@ const ja = {
     'View Finding': '詳細を見る',
     'View Item': '詳細を見る',
     'Test Notification': '通知のテスト',
-    Disable: '無効化する',
+    'Disable Admin': '管理者権限を無効化する',
   },
   message: {
     'Do you really want to delete this?': '本当に削除してよろしいですか？',
@@ -268,8 +268,7 @@ const ja = {
       'テスト通知を送信してよろしいですか?',
     'REQUEST PROJECT ROLE COMPLETED':
       'プロジェクトへのアクセス権を管理者にリクエストしました。',
-    'Do you want to disable system admin?':
-      '本当に無効化しますか？',
+    'Do you want to disable admin?': '本当に無効化しますか？',
   },
   error: {
     'Sorry, Please access again after a while.':

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -255,6 +255,7 @@ const ja = {
     'View Finding': '詳細を見る',
     'View Item': '詳細を見る',
     'Test Notification': '通知のテスト',
+    Disable: '無効化する',
   },
   message: {
     'Do you really want to delete this?': '本当に削除してよろしいですか？',
@@ -267,6 +268,8 @@ const ja = {
       'テスト通知を送信してよろしいですか?',
     'REQUEST PROJECT ROLE COMPLETED':
       'プロジェクトへのアクセス権を管理者にリクエストしました。',
+    'Do you want to disable system admin?':
+      '本当に無効化しますか？',
   },
   error: {
     'Sorry, Please access again after a while.':

--- a/src/mixin/api/iam.js
+++ b/src/mixin/api/iam.js
@@ -45,6 +45,18 @@ const iam = {
         })
       return res.data.data.user
     },
+    async updateUserAdminAPI(userID, isAdmin) {
+      const param = {
+        user_id: userID,
+        is_admin: isAdmin,
+      }
+      const res = await this.$axios
+        .post('/admin/update-user-admin/', param)
+        .catch((err) => {
+          return Promise.reject(err)
+        })
+      return res.data.data.user
+    },
 
     // Role API
     async listRoleAPI(searchCond) {
@@ -62,17 +74,6 @@ const iam = {
       }
       return res.data.data.role_id
     },
-    async listAdminRoleAPI(name) {
-      const res = await this.$axios
-        .get('/admin/list-admin-role/?name=' + name)
-        .catch((err) => {
-          return Promise.reject(err)
-        })
-      if (!res.data.data.role_id) {
-        return []
-      }
-      return res.data.data.role_id
-    },
     async getRoleAPI(roleID) {
       const res = await this.$axios
         .get(
@@ -81,14 +82,6 @@ const iam = {
             '&role_id=' +
             roleID
         )
-        .catch((err) => {
-          return Promise.reject(err)
-        })
-      return res.data.data.role
-    },
-    async getAdminRoleAPI(roleID) {
-      const res = await this.$axios
-        .get('/admin/get-admin-role/?role_id=' + roleID)
         .catch((err) => {
           return Promise.reject(err)
         })
@@ -122,18 +115,6 @@ const iam = {
         })
       return res
     },
-    async attachAdminRoleAPI(userID, roleID) {
-      const param = {
-        user_id: userID,
-        role_id: roleID,
-      }
-      const res = await this.$axios
-        .post('/admin/attach-admin-role/', param)
-        .catch((err) => {
-          return Promise.reject(err)
-        })
-      return res
-    },
     async detachRoleAPI(userID, roleID) {
       const param = {
         project_id: this.getCurrentProjectID(),
@@ -142,18 +123,6 @@ const iam = {
       }
       const res = await this.$axios
         .post('/iam/detach-role/', param)
-        .catch((err) => {
-          return Promise.reject(err)
-        })
-      return res
-    },
-    async detachAdminRoleAPI(userID, roleID) {
-      const param = {
-        user_id: userID,
-        role_id: roleID,
-      }
-      const res = await this.$axios
-        .post('/admin/detach-admin-role/', param)
         .catch((err) => {
           return Promise.reject(err)
         })

--- a/src/view/admin/User.vue
+++ b/src/view/admin/User.vue
@@ -237,6 +237,12 @@ import iam from '@/mixin/api/iam'
 import BottomSnackBar from '@/component/widget/snackbar/BottomSnackBar.vue'
 import UserList from '@/component/widget/list/UserList.vue'
 import { VDataTableServer } from 'vuetify/labs/VDataTable'
+
+const ADMIN_STATUS = {
+  ENABLED: true,
+  DISABLED: false,
+}
+
 export default {
   name: 'AdminUser',
   mixins: [mixin, iam],
@@ -269,9 +275,17 @@ export default {
         updated_at: '',
       },
       table: {
-        options: { page: 1, itemsPerPage: 10, sortBy: [{ key: 'user_id', order: 'asc' }] },
+        options: {
+          page: 1,
+          itemsPerPage: 10,
+          sortBy: [{ key: 'user_id', order: 'asc' }],
+        },
         actions: [
-          { text: 'Disable Admin', icon: 'mdi-delete', click: this.handleDisableAdmin },
+          {
+            text: 'Disable Admin',
+            icon: 'mdi-delete',
+            click: this.handleDisableAdmin,
+          },
         ],
         total: 0,
         footer: {
@@ -366,14 +380,14 @@ export default {
           userNames.push(item.name)
         })
       )
-      
+
       // Sort items by user_id in ascending order
       items.sort((a, b) => {
         if (a.user_id < b.user_id) return -1
         if (a.user_id > b.user_id) return 1
         return 0
       })
-      
+
       this.table.items = items
       this.userIDList = userIDs.sort()
       this.userNameList = userNames.sort()
@@ -425,14 +439,14 @@ export default {
       this.inviteUserDialog = true
     },
     handleEditSubmit() {
-      this.putItem(true)
+      this.putItem(ADMIN_STATUS.ENABLED)
     },
     handleDisableAdmin(item) {
       this.assignDataModel(item.value)
       this.disableAdminDialog = true
     },
     async handleDisableAdminSubmit() {
-      this.putItem(false)
+      this.putItem(ADMIN_STATUS.DISABLED)
     },
     handleSearch() {
       let searchCond = ''

--- a/src/view/admin/User.vue
+++ b/src/view/admin/User.vue
@@ -76,7 +76,6 @@
                 no-data-text="No data."
                 class="elevation-1"
                 item-key="user_id"
-                @click:row="handleRowClick"
                 @update:options="updateOptions"
               >
                 <template v-slot:[`item.avator`]>
@@ -113,8 +112,8 @@
       </v-row>
     </v-container>
 
-    <!-- Edit Dialog -->
-    <v-dialog v-model="editDialog" max-width="40%">
+    <!-- Invite User Dialog -->
+    <v-dialog v-model="inviteUserDialog" max-width="40%">
       <v-card>
         <v-card-title>
           <v-icon large>mdi-account-multiple</v-icon>
@@ -160,7 +159,7 @@
               <v-btn
                 variant="outlined"
                 color="grey-darken-1"
-                @click="editDialog = false"
+                @click="inviteUserDialog = false"
               >
                 {{ $t(`btn['CANCEL']`) }}
               </v-btn>
@@ -178,12 +177,12 @@
       </v-card>
     </v-dialog>
 
-    <!-- Disable Dialog -->
-    <v-dialog v-model="deleteDialog" max-width="40%">
+    <!-- Disable Admin Dialog -->
+    <v-dialog v-model="disableAdminDialog" max-width="40%">
       <v-card>
         <v-card-title>
           <span class="mx-4 text-h5">
-            {{ $t(`message['Do you want to disable system admin?']`) }}
+            {{ $t(`message['Do you want to disable admin?']`) }}
           </span>
         </v-card-title>
 
@@ -212,7 +211,7 @@
           <v-btn
             variant="outlined"
             color="grey-darken-1"
-            @click="disableDialog = false"
+            @click="disableAdminDialog = false"
           >
             {{ $t(`btn['CANCEL']`) }}
           </v-btn>
@@ -220,7 +219,7 @@
             variant="outlined"
             color="red-darken-1"
             :loading="loading"
-            @click="handleDisableSubmit"
+            @click="handleDisableAdminSubmit"
           >
             {{ $t(`btn['DISABLE']`) }}
           </v-btn>
@@ -270,9 +269,9 @@ export default {
         updated_at: '',
       },
       table: {
-        options: { page: 1, itemsPerPage: 10, sortBy: ['user_id'] },
+        options: { page: 1, itemsPerPage: 10, sortBy: [{ key: 'user_id', order: 'asc' }] },
         actions: [
-          { text: 'Disable', icon: 'mdi-delete', click: this.handleDisable },
+          { text: 'Disable Admin', icon: 'mdi-delete', click: this.handleDisableAdmin },
         ],
         total: 0,
         footer: {
@@ -282,8 +281,8 @@ export default {
         items: [],
       },
       users: [],
-      deleteDialog: false,
-      editDialog: false,
+      disableAdminDialog: false,
+      inviteUserDialog: false,
       userDialog: false,
     }
   },
@@ -367,9 +366,17 @@ export default {
           userNames.push(item.name)
         })
       )
+      
+      // Sort items by user_id in ascending order
+      items.sort((a, b) => {
+        if (a.user_id < b.user_id) return -1
+        if (a.user_id > b.user_id) return 1
+        return 0
+      })
+      
       this.table.items = items
-      this.userIDList = userIDs
-      this.userNameList = userNames
+      this.userIDList = userIDs.sort()
+      this.userNameList = userNames.sort()
       this.loading = false
     },
     clearList() {
@@ -393,8 +400,8 @@ export default {
       await new Promise((resolve) => setTimeout(resolve, 500))
       this.$refs.snackbar.notifySuccess(msg)
       this.loading = false
-      this.deleteDialog = false
-      this.editDialog = false
+      this.disableAdminDialog = false
+      this.inviteUserDialog = false
       this.handleSearch()
     },
 
@@ -409,22 +416,22 @@ export default {
         name: '',
         updated_at: '',
       }
-      this.editDialog = true
+      this.inviteUserDialog = true
     },
     handleEdit(item) {
       this.userForm.clickNew = false
       this.assignDataModel(item.value)
       this.loadRoleList()
-      this.editDialog = true
+      this.inviteUserDialog = true
     },
     handleEditSubmit() {
       this.putItem(true)
     },
-    handleDelete(item) {
+    handleDisableAdmin(item) {
       this.assignDataModel(item.value)
-      this.deleteDialog = true    
+      this.disableAdminDialog = true
     },
-    async handleDeleteSubmit() {
+    async handleDisableAdminSubmit() {
       this.putItem(false)
     },
     handleSearch() {


### PR DESCRIPTION
Gateway、Webの変更に関連してWebのUIを変更します。
https://github.com/ca-risken/core/pull/386
https://github.com/ca-risken/gateway/pull/182

- RoleListに関する機能の削除
- ダイアログの名前変更、機能変更など

観点はコメントに記載しています

UIイメージ
Admin Menu -> 管理者ユーザを開いた状態です

<img width="1023" alt="スクリーンショット 2025-06-10 午後3 27 07" src="https://github.com/user-attachments/assets/a1e99c75-3cda-4d89-b3cf-079a0ef21fcf" />
<img width="890" alt="スクリーンショット 2025-06-10 午後3 27 31" src="https://github.com/user-attachments/assets/9a4328d5-895a-4179-9027-640647f0975b" />
<img width="879" alt="スクリーンショット 2025-06-10 午後3 27 41" src="https://github.com/user-attachments/assets/2ac66b66-bf01-4bea-af35-898aa63ad9dc" />
