### PR TITLE
add: pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: make-fmt
+        name: make fmt
+        entry: make fmt
+        language: system
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ local-clean:
 .PHONY: install
 install:
 	yarn install
+	pip install pre-commit
+	pre-commit install
 
 .PHONY: build
 build: lint

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This module requires the following modules:
 
 - [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - [yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable)
+- [pip](https://pip.pypa.io/en/latest/installation/)
 
 ### Install packages
 


### PR DESCRIPTION
pre-commitを追加します。make installで動くようになります。

動作確認済です。

```
❯ g cm -m "add: pre-commit" --amend
make fmt.................................................................Failed
- hook id: make-fmt
- files were modified by this hook
```

