### PR TITLE
[add]severity mention explain

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -399,7 +399,7 @@ const en = {
       '(You need to issue the URL in advance.)':
         '(You need to issue the URL in advance.)',
       'severity mention explanation':
-        'If you insert &lt;&#64;severity&gt; at the beginning of the message, users will be mentioned according to the severity of the vulnerability.',
+        'By inserting &lt;&#64;severity&gt;, users will be mentioned based on the severity of the vulnerability.',
     },
     report: {
       'All Data Source': 'All Data Source',

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -398,8 +398,8 @@ const en = {
         'Please specify the Slack Webhook URL.',
       '(You need to issue the URL in advance.)':
         '(You need to issue the URL in advance.)',
-      'severity mention':
-        'When you mention &#64;severity, it will be mentioned according to the severity of the vulnerability.',
+      'severity mention explanation':
+        'If you insert &lt;&#64;severity&gt; at the beginning of the message, users will be mentioned according to the severity of the vulnerability.',
     },
     report: {
       'All Data Source': 'All Data Source',

--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -398,6 +398,8 @@ const en = {
         'Please specify the Slack Webhook URL.',
       '(You need to issue the URL in advance.)':
         '(You need to issue the URL in advance.)',
+      'severity mention':
+        'When you mention &#64;severity, it will be mentioned according to the severity of the vulnerability.',
     },
     report: {
       'All Data Source': 'All Data Source',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -398,6 +398,8 @@ const ja = {
         'SlackのWebhookURLを指定してください。',
       '(You need to issue the URL in advance.)':
         '(事前にURLを発行する必要があります。)',
+      'severity mention':
+        '&#64;severityにメンションすると、脆弱性の重大度に応じてメンションされます。',
     },
     report: {
       'All Data Source': '全データソース',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -399,7 +399,7 @@ const ja = {
       '(You need to issue the URL in advance.)':
         '(事前にURLを発行する必要があります。)',
       'severity mention':
-        '&#64;severityにメンションすると、脆弱性の重大度に応じてメンションされます。',
+        '&lt;&#64;severity&gt;を文頭に挿入すると、脆弱性の重大度に応じてメンションされます。',
     },
     report: {
       'All Data Source': '全データソース',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -399,7 +399,7 @@ const ja = {
       '(You need to issue the URL in advance.)':
         '(事前にURLを発行する必要があります。)',
       'severity mention':
-        '&lt;&#64;severity&gt;を文頭に挿入すると、脆弱性の重大度に応じてメンションされます。',
+        '&lt;&#64;severity&gt;を挿入すると、脆弱性の重大度に応じてメンションされます。',
     },
     report: {
       'All Data Source': '全データソース',

--- a/src/view/alert/Notification.vue
+++ b/src/view/alert/Notification.vue
@@ -182,6 +182,11 @@
                       {{ $t(`view.alert['Show options']`) }}
                     </v-expansion-panel-title>
                     <v-expansion-panel-text>
+                      <p class="text-body-2 ma-4">
+                        <span
+                          v-html="$t(`view.alert['severity mention']`)"
+                        ></span>
+                      </p>
                       <v-text-field
                         v-model="dataModel.custom_message"
                         :counter="500"
@@ -241,6 +246,11 @@
                       {{ $t(`view.alert['Show options']`) }}
                     </v-expansion-panel-title>
                     <v-expansion-panel-text>
+                      <p class="text-body-2 ma-4">
+                        <span
+                          v-html="$t(`view.alert['severity mention']`)"
+                        ></span>
+                      </p>
                       <v-text-field
                         v-model="dataModel.custom_message"
                         :counter="500"


### PR DESCRIPTION
`@severity`にメンション時に脆弱性重大度に応じたメンションが飛ぶ事を説明として追加。(以下画像)
- 実装概要
  - slack app , webhook 両方に実装
  - 英語では以下の文面になる。
    - When you mention @severity, it will be mentioned according to the severity of the vulnerability. 
    - `@`がvueで特殊文字として扱われるため、v-htmlを使用。
<img width="595" height="439" alt="スクリーンショット 2025-07-22 11 07 19" src="https://github.com/user-attachments/assets/4b5d94c9-975d-44ec-b1bd-11811dbded0f" />
