### PR TITLE
feat: add Markdown component to FindingDetailDialog

### DIFF
--- a/src/component/dialog/finding/Detail.vue
+++ b/src/component/dialog/finding/Detail.vue
@@ -411,6 +411,7 @@ import JsonView from '@/component/text/JsonView.vue'
 import AIPanel from '@/component/text/AIPanel.vue'
 import FindingTriageDialog from '@/component/dialog/finding/Triage.vue'
 import CopyLink from '@/component/link/CopyLink.vue'
+import Markdown from '@/component/text/Markdown.vue'
 
 export default {
   name: 'FindingDetailDialog',
@@ -420,6 +421,7 @@ export default {
     AIPanel,
     FindingTriageDialog,
     CopyLink,
+    Markdown,
   },
   mixins: [mixin],
   props: {


### PR DESCRIPTION
pend_noteをを表示できるように修正します。ローカルで動作確認済みです。
<img width="1321" height="319" alt="スクリーンショット 2025-09-30 午後4 17 59" src="https://github.com/user-attachments/assets/7822fec8-5439-494b-9add-e18bda1535eb" />
