### PR TITLE
fix: use mixin method for putOrganizationPolicy to align with API parameter structure

### DIFF
--- a/src/view/iam/Policy.vue
+++ b/src/view/iam/Policy.vue
@@ -443,15 +443,10 @@ export default {
     async putItem() {
       let param
       if (this.isOrganizationMode) {
-        param = {
-          organization_id: this.getCurrentOrganizationID(),
-          policy: {
-            name: this.policyModel.name,
-            organization_id: this.getCurrentOrganizationID(),
-            action_ptn: this.policyModel.action_ptn,
-          },
-        }
-        await this.putOrganizationPolicyAPI(param).catch((err) => {
+        await this.putOrganizationPolicyAPI(
+          this.policyModel.name,
+          this.policyModel.action_ptn
+        ).catch((err) => {
           this.$refs.snackbar.notifyError(err.response.data)
           return Promise.reject(err)
         })


### PR DESCRIPTION
Webのリクエスト形式にバグがあり、以下のようになっていました。これを修正します。
<img width="598" height="92" alt="スクリーンショット 2026-03-27 午後3 10 25" src="https://github.com/user-attachments/assets/8e23bd24-3ddf-45bf-b0e4-99916429abbd" />


動作確認済みです。
<img width="893" height="361" alt="スクリーンショット 2026-03-27 午後3 11 04" src="https://github.com/user-attachments/assets/5ae2f7b1-1b1f-42fc-9ce3-b574c67e9bbe" />
