### PR TITLE
fix: Rename organization-iam access-token path to remove redundant prefix

### DIFF
--- a/src/router/config.js
+++ b/src/router/config.js
@@ -503,7 +503,7 @@ export const appRoute = [
             component: () => import('@/view/iam/Policy.vue'),
           },
           {
-            path: '/organization-iam/organization-access-token',
+            path: '/organization-iam/access-token',
             name: 'OrganizationAccessToken',
             meta: {
               title: 'AccessToken',

--- a/src/router/menu.js
+++ b/src/router/menu.js
@@ -71,7 +71,7 @@ export const menuDefinition = [
           { title: 'Policy', path: '/organization-iam/policy' },
           {
             title: 'AccessToken',
-            path: '/organization-iam/organization-access-token',
+            path: '/organization-iam/access-token',
           },
           {
             title: 'User Reservation',


### PR DESCRIPTION
Organization IAMのアクセストークンのメニューとルーターのパスから、organizationを削除します。他のorganization iamのパス名と比べると、organizationが冗長だったためです。
ローカルでOrganization Access Tokenの画面が開けることを確認済みです。