### PR TITLE
fix: Skip putAlertFirstViewedAt when project_id is 0 and remove unnecessary UserInProject check

### DIFF
--- a/src/mixin/index.js
+++ b/src/mixin/index.js
@@ -665,6 +665,9 @@ let mixin = {
       if (query.project_id && query.project_id != '') {
         project_id = parseInt(query.project_id)
       }
+      if (project_id === 0) {
+        return
+      }
       let user_id
       if (store.state && store.state.user && store.state.user.user_id) {
         user_id = store.state.user.user_id
@@ -674,29 +677,7 @@ let mixin = {
       if (!user_id) {
         return
       }
-      const userInProject = await this.UserInProject(project_id, user_id)
-      if (project_id === 0 || !userInProject) {
-        return
-      }
-      await this.putAlertFirstViewedAt(project_id, user_id)
-      return
-    },
-    async UserInProject(project_id, user_id) {
-      const searchCond = '&project_id=' + project_id + '&user_id=' + user_id
-      const userIDs = await this.listUserAPI(searchCond).catch((err) => {
-        return Promise.reject(err)
-      })
-      if (!userIDs) {
-        return false
-      }
-      const user = store.state.user
-      if (!user || !user.user_id) {
-        return false
-      }
-      if (userIDs.includes(user.user_id)) {
-        return true
-      }
-      return false
+      await this.putAlertFirstViewedAt(project_id)
     },
   },
 }


### PR DESCRIPTION
UpdateAlertFirstViewedAtでUserInProjectのチェックを行わないようにします。

アラート画面をOrgのロールを持っているユーザーまたはシステム管理者が開いた時、当該プロジェクトのロールを持っていない場合はput-alert-first-viewed-atが呼ばれない問題がありました。実装することについて考えましたが、フロントエンドでOrgのロール、システム管理者のチェックまで行う必要があるのと、今回のような実装漏れを考慮して削除しました。

これを消しても、ルーターガードによって、alert画面には到達できない想定で、 put-alert-first-viewed-atのGatewayで、認可制御が保証されているため、問題ない認識です。