### PR TITLE
feat: add project_ptn input to organization policy form

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -207,6 +207,7 @@ const en = {
     'Policy Name': 'Policy Name',
     'Portscan Setting ID': 'Portscan Setting ID',
     'Portscan Target ID': 'Portscan Target ID',
+    'Project Pattern': 'Project Pattern',
     Recommend: 'Recommend',
     Recommendation: 'Recommendation',
     'Recommend ID': 'Recommend ID',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -207,6 +207,7 @@ const ja = {
     'Policy Name': 'ポリシー名',
     'Portscan Setting ID': 'ポートスキャン設定ID',
     'Portscan Target ID': 'ポートスキャン対象ID',
+    'Project Pattern': 'プロジェクトパターン',
     Recommend: '推奨',
     Recommendation: '推奨事項',
     'Recommend ID': 'レコメンドID',

--- a/src/mixin/api/organization_iam.js
+++ b/src/mixin/api/organization_iam.js
@@ -92,11 +92,12 @@ const organization_iam = {
       }
       return res.data.data.policy
     },
-    async putOrganizationPolicyAPI(name, action_ptn) {
+    async putOrganizationPolicyAPI(name, action_ptn, project_ptn) {
       const param = {
         organization_id: this.getCurrentOrganizationID(),
         name: name,
         action_ptn: action_ptn,
+        project_ptn: project_ptn,
       }
       const res = await this.$axios
         .post('/organization-iam/put-policy', param)

--- a/src/view/iam/Policy.vue
+++ b/src/view/iam/Policy.vue
@@ -94,6 +94,21 @@
                     </v-card-text>
                   </v-card>
                 </template>
+                <template
+                  v-if="isOrganizationMode"
+                  v-slot:[`item.project_ptn`]="{ item }"
+                >
+                  <v-card
+                    label
+                    elevation="1"
+                    color="amber-lighten-5"
+                    class="mx-auto"
+                  >
+                    <v-card-text class="font-weight-bold">
+                      {{ item.value.project_ptn }}
+                    </v-card-text>
+                  </v-card>
+                </template>
                 <template v-slot:[`item.updated_at`]="{ item }">
                   <v-chip>{{ formatTime(item.value.updated_at) }}</v-chip>
                 </template>
@@ -176,6 +191,14 @@
               "
               :placeholder="policyForm.resource_ptn.placeholder"
               disabled
+            ></v-text-field>
+            <v-text-field
+              v-if="isOrganizationMode"
+              v-model="policyModel.project_ptn"
+              :rules="policyForm.project_ptn.validator"
+              :label="$t(`item['` + policyForm.project_ptn.label + `']`) + ' *'"
+              :placeholder="policyForm.project_ptn.placeholder"
+              required
             ></v-text-field>
             <v-divider class="mt-3 mb-3"></v-divider>
             <v-card-actions>
@@ -276,6 +299,16 @@ export default {
               'Resource Pattern must be compilable regular expression',
           ],
         },
+        project_ptn: {
+          label: 'Project Pattern',
+          placeholder: '`.*` for all projects',
+          validator: [
+            (v) => !!v || 'Project Pattern is required',
+            (v) =>
+              this.compilableRegexp(v) ||
+              'Project Pattern must be compilable regular expression',
+          ],
+        },
       },
       policyNameList: [],
       policyModel: {
@@ -283,6 +316,7 @@ export default {
         name: '',
         action_ptn: '',
         resource_ptn: '.*', // fixed
+        project_ptn: '.*',
         updated_at: '',
       },
       table: {
@@ -348,6 +382,13 @@ export default {
           align: 'start',
           sortable: false,
           key: 'resource_ptn',
+        })
+      } else {
+        baseHeaders.push({
+          title: this.$i18n.t('item["Project Pattern"]'),
+          align: 'start',
+          sortable: false,
+          key: 'project_ptn',
         })
       }
 
@@ -445,7 +486,8 @@ export default {
       if (this.isOrganizationMode) {
         await this.putOrganizationPolicyAPI(
           this.policyModel.name,
-          this.policyModel.action_ptn
+          this.policyModel.action_ptn,
+          this.policyModel.project_ptn
         ).catch((err) => {
           this.$refs.snackbar.notifyError(err.response.data)
           return Promise.reject(err)
@@ -484,6 +526,7 @@ export default {
         name: '',
         action_ptn: '',
         resource_ptn: '.*',
+        project_ptn: '.*',
         updated_at: '',
       }
       this.policyForm.newPolicy = true
@@ -514,6 +557,7 @@ export default {
         name: '',
         action_ptn: '',
         resource_ptn: '.*',
+        project_ptn: '.*',
         updated_at: '',
       }
       this.policyModel = Object.assign(this.policyModel, item)


### PR DESCRIPTION
## 概要

 Organization スコープのIAMポリシーに対して、対象プロジェクトを正規表現で絞り込むための project_ptn フィールドをポリシーのリストに追加します。


## 変更点

 src/view/iam/Policy.vue

- Organization モードのポリシーテーブルに project_ptn カラムと編集フィールドを追加する。
  - テーブルに "Project Pattern" 列を追加（Organization モード時のみ表示、amber スタイル）
  - Project モードの resource_ptn と排他になるよう条件分岐を整理
  - 編集ダイアログに project_ptn 入力欄を追加（Organization モード限定・必須・正規表現バリデーション付き）
- policyModel のデフォルト値を .*（全プロジェクト対象）に設定。
- putOrganizationPolicyAPI 呼び出しに policyModel.project_ptn を引き渡し。

 ### src/mixin/api/organization_iam.js
  - putOrganizationPolicyAPI(name, action_ptn) を putOrganizationPolicyAPI(name, action_ptn, project_ptn) に拡張し、リクエストボディに project_ptn を追加。

### src/i18n/message/{en,ja}.js

  -   Project Pattern / プロジェクトパターン の翻訳キーを追加。

 ## 動作確認ポイント

- [x]   Organization モードでポリシー新規作成時、Project Pattern 入力欄が表示され、デフォルト値が空文字になっていること
- [x]   Project Pattern 未入力で保存しようとするとバリデーションエラーになること
- [x]   既存ポリシー編集時、サーバから取得した project_ptn の値が Project Pattern に正しく反映されること
- [x]   不正な正規表現（例: [）を入力すると Project Pattern must be compilable regular expression エラーが出ること
- [x]   Organization Modeのポリシーリストに Project Pattern カラムが表示され、Resource Pattern カラムが非表示になっていること
- [x]   Project Modeでは Resource Pattern カラムが表示され、Project Pattern 入力欄・カラムが現れないこと
- [x]   保存後、リクエストの payload に project_ptn が含まれており、Core (org_iam.PutPolicyRequest) のバリデーション (min_len=1) を通過すること
- [x]   i18n: 日本語/英語切替で プロジェクトパターン / Project Pattern が正しく表示されること