### PR TITLE
fix: handle null user in getPendUser to prevent crash on deleted users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine as builder
 WORKDIR /app
 COPY ./ ./
 RUN corepack enable
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 RUN NODE_OPTIONS=--openssl-legacy-provider pnpm run build-prd
 
 FROM nginx:stable-alpine as production-stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine as builder
 WORKDIR /app
 COPY ./ ./
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
+RUN pnpm install
 RUN NODE_OPTIONS=--openssl-legacy-provider pnpm run build-prd
 
 FROM nginx:stable-alpine as production-stage

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1513,7 +1513,7 @@ export default {
     },
     async getPendUser(userID) {
       const user = await this.getUserAPI(userID)
-      return user.name
+      return user?.name || ''
     },
 
     // finish

--- a/src/view/finding/Finding.vue
+++ b/src/view/finding/Finding.vue
@@ -1512,7 +1512,10 @@ export default {
       }
     },
     async getPendUser(userID) {
-      const user = await this.getUserAPI(userID)
+      const user = await this.getUserAPI(userID).catch((err) => {
+        console.error(err)
+        return null
+      })
       return user?.name || ''
     },
 


### PR DESCRIPTION
## Summary
- 削除済みユーザーが `pend_user_id` として `pend_finding` に残っている場合、`getPendUser` が `user.name` を参照してクラッシュしていた問題を修正
- `user?.name || ''` に変更し、ユーザーが存在しない場合は空文字を返すよう対応

## Test plan
- [x] 存在しないユーザー (`pend_user_id=99999`) でアーカイブされた Finding を作成
- [x] Finding 一覧のアーカイブタブを開き、クラッシュせずに表示されることを確認