### PR TITLE
fix: migrate onlyBuiltDependencies to allowBuilds for pnpm v11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
-onlyBuiltDependencies:
-  - esbuild
-  - vue-demi
-  - core-js
+allowBuilds:
+  core-js: true
+  esbuild: true
+  vue-demi: true
 minimumReleaseAge: 10080
 overrides:
   node-ipc: "9.2.1"


### PR DESCRIPTION
## Summary
- pnpm v11 で `onlyBuiltDependencies` が廃止され `allowBuilds` に変更されたため、`pnpm-workspace.yaml` の設定を移行
- これにより Docker ビルド時の `ERR_PNPM_IGNORED_BUILDS` エラーを解消

## Test plan
- [x] Docker ビルドが通ること (`pnpm install` で `ERR_PNPM_IGNORED_BUILDS` が出ないこと)
- [x] `core-js`, `esbuild`, `vue-demi` のビルドスクリプトが正常に実行されること