### PR TITLE
Project/Organization選択の検索文字列を保持する

### DIFF
--- a/src/component/AppToolbar.vue
+++ b/src/component/AppToolbar.vue
@@ -120,6 +120,7 @@
     :loading="loading"
     :current-entity-id="currentProjectID"
     :custom-filter="customFilter"
+    persistent-search
     @item-selected="handleProjectSelected"
     @edit-entity="handleSettingProject"
     @create-entity="handleNewProject"
@@ -132,6 +133,7 @@
     :items="organizationTable.item"
     :loading="loading"
     :current-entity-id="currentOrganizationID"
+    persistent-search
     @item-selected="handleOrganizationSelected"
     @edit-entity="handleOrganizationSetting"
     @create-entity="handleNewOrganization"

--- a/src/component/dialog/ProjectOrgSelectDialog.vue
+++ b/src/component/dialog/ProjectOrgSelectDialog.vue
@@ -91,6 +91,7 @@
 
 <script>
 import { VDataTable } from 'vuetify/labs/VDataTable'
+import store from '@/store'
 
 export default {
   name: 'ProjectOrgSelectDialog',
@@ -123,10 +124,14 @@ export default {
       type: Function,
       default: null,
     },
+    persistentSearch: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
-      searchText: '',
+      localSearchText: '',
       options: {
         itemsPerPage: 10,
         page: 1,
@@ -144,6 +149,25 @@ export default {
       },
       set(value) {
         this.$emit('update:modelValue', value)
+      },
+    },
+    searchText: {
+      get() {
+        if (!this.persistentSearch) {
+          return this.localSearchText
+        }
+        return store.state.projectOrgSearch?.[this.entityType] || ''
+      },
+      set(value) {
+        const searchText = value || ''
+        if (!this.persistentSearch) {
+          this.localSearchText = searchText
+          return
+        }
+        store.commit('updateProjectOrgSearch', {
+          entityType: this.entityType,
+          searchText,
+        })
       },
     },
     entityTitle() {
@@ -217,7 +241,6 @@ export default {
   methods: {
     handleClose() {
       this.dialog = false
-      this.searchText = ''
     },
     handleItemClick(event, item) {
       this.$emit('item-selected', item.item.value)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -17,6 +17,10 @@ const store = createStore({
       interval: {},
       locale: {},
       findingHistory: [],
+      projectOrgSearch: {
+        project: '',
+        organization: '',
+      },
     }
   },
   mutations: {
@@ -40,6 +44,15 @@ const store = createStore({
     },
     updateFindingHistory: (state, payload) => {
       state.findingHistory = payload
+    },
+    updateProjectOrgSearch: (state, payload) => {
+      if (!['project', 'organization'].includes(payload.entityType)) {
+        return
+      }
+      state.projectOrgSearch = {
+        ...state.projectOrgSearch,
+        [payload.entityType]: payload.searchText || '',
+      }
     },
   },
   plugins: [vuexLocal.plugin],


### PR DESCRIPTION
## PRの概要

Project / Organization の選択ダイアログでは、一覧を絞り込む検索文字列がダイアログを閉じた時点で初期化されていたため、別画面へ遷移した後に再度開くとフィルター条件が失われていました。この PR では、ヘッダーから開く Project / Organization 選択ダイアログだけ検索文字列を Vuex の永続化対象に保存し、画面遷移やリロードをまたいでも直前のフィルター条件を復元できるようにしています。共通ダイアログ自体は opt-in の `persistent-search` 指定時だけ永続化するため、既存の選択画面や招待画面での一時的な検索挙動には影響しません。

| 操作 | 変更前 | 変更後 |
|---|---|---|
| 検索文字を入力してダイアログを閉じる | 次回表示時に空欄へ戻る | 次回表示時も検索文字が残る |
| Project / Organization を切り替える | 検索文字は閉じるたびに失われる | Project 用と Organization 用に別々に保持される |
| 検索文字を消す | 閉じる操作で消える | 検索欄の clear 操作で消える |

## レビュー観点例

- [ ] ヘッダー以外の `ProjectOrgSelectDialog` 利用箇所に不要な永続化影響がない点
- [ ] Project と Organization の検索文字列を同じ Vuex 永続化領域で分離して扱えている点
- [ ] ダイアログを閉じる操作と検索条件を明示的に消す操作の責務分離が自然な点
- [ ] 既存 localStorage の Vuex 永続化データに `projectOrgSearch` が追加されても後方互換性を保てる点
