### PR TITLE
Add GitHub App install settings page

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -51,6 +51,7 @@ const en = {
     EDIT: 'EDIT',
     'Re-generate': 'Re-generate',
     DOWNLOAD_PDF: 'Download PDF',
+    'OPEN INSTALL PAGE': 'Open install page',
   },
   menu: {
     Home: 'Home',
@@ -98,6 +99,7 @@ const en = {
     OSINT: 'OSINT',
     'OSINT DataSource': 'OSINT DataSource',
     GitHub: 'GitHub',
+    'GitHub App': 'GitHub App',
     User: 'User', // IAM
     'User Reservation': 'User Reservation', //IAM
     Role: 'Role', // IAM
@@ -168,6 +170,25 @@ const en = {
     'Gitleaks Status': 'Gitleaks Status',
     'CodeScan Setting': 'CodeScan Setting',
     'CodeScan Status': 'CodeScan Status',
+    'GitHub App Install Page Lead':
+      'This is the initial setup for an organization administrator or user owner. After installation, continue the scan setup from the GitHub setting page.',
+    'GitHub App Install Section Title': 'Install GitHub App',
+    'GitHub App Install Section Lead':
+      'Review the following items, then open the GitHub App installation page.',
+    'GitHub App Install Owner Notice Primary':
+      'Only the owner of the target GitHub organization, or the target user account owner, can install the GitHub App.',
+    'GitHub App Install Owner Notice Secondary':
+      'If you do not have permission, ask the organization owner to install it.',
+    'GitHub App Install Checklist Owner':
+      'You have owner permission for the target organization or user account.',
+    'GitHub App Install Checklist Target':
+      'Select the target organization or user on GitHub.',
+    'GitHub App Install Checklist After Before Link':
+      'After installation, save the GitHub App setting and run LINK GITHUB from the ',
+    'GitHub App Install Checklist After Link Text': 'GitHub setting page',
+    'GitHub App Install Checklist After After Link': '.',
+    'GitHub App Install Before Open Note':
+      'The installation page opens on GitHub.',
     'Google Data Source': 'Google Data Source',
     'Google Data Source ID': 'Google Data Source ID',
     Keyword: 'Keyword',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -51,6 +51,7 @@ const ja = {
     EDIT: '編集',
     'Re-generate': '再生成',
     DOWNLOAD_PDF: 'PDFダウンロード',
+    'OPEN INSTALL PAGE': 'インストールページを開く',
   },
   menu: {
     Home: 'ホーム',
@@ -98,6 +99,7 @@ const ja = {
     OSINT: 'OSINT',
     'OSINT DataSource': 'OSINTデータソース',
     GitHub: 'GitHub',
+    'GitHub App': 'GitHub App',
     User: 'ユーザ',
     'User Reservation': 'ユーザ予約',
     Role: 'ロール',
@@ -166,6 +168,25 @@ const ja = {
     'GitHub Setting ID': 'GitHub Setting ID',
     'Gitleaks Setting': 'Gitleaks設定',
     'CodeScan Setting': 'CodeScan設定',
+    'GitHub App Install Page Lead':
+      'Organization管理者またはUserのOwnerが実施する初回セットアップです。インストール完了後にGitHub設定からスキャン設定を進められます。',
+    'GitHub App Install Section Title': 'GitHub Appのインストール',
+    'GitHub App Install Section Lead':
+      '以下を確認した上で、GitHub Appのインストールページを開いてください。',
+    'GitHub App Install Owner Notice Primary':
+      'GitHub Appをインストールできるのは、対象GitHub OrganizationのOwner、または対象User本人のみです。',
+    'GitHub App Install Owner Notice Secondary':
+      '権限がない場合は、Organization Ownerにインストールを依頼してください。',
+    'GitHub App Install Checklist Owner':
+      '対象OrganizationまたはUserのOwner権限を持っていること',
+    'GitHub App Install Checklist Target':
+      'GitHub上でインストール対象のOrganizationまたはUserを選択すること',
+    'GitHub App Install Checklist After Before Link': 'インストール後、',
+    'GitHub App Install Checklist After Link Text': 'RISKEN上のGitHub設定画面',
+    'GitHub App Install Checklist After After Link':
+      'でGitHub App方式の設定保存とGitHub連携を実施すること',
+    'GitHub App Install Before Open Note':
+      'インストールページはGitHubの画面で開きます。',
     'Google Data Source': 'Google データソース',
     'Google Data Source ID': 'Google データソースID',
     Keyword: 'キーワード',

--- a/src/router/config.js
+++ b/src/router/config.js
@@ -404,6 +404,14 @@ export const appRoute = [
         ],
       },
       {
+        path: '/settings/github-app',
+        name: 'GitHubAppInstall',
+        meta: {
+          title: 'GitHub App',
+        },
+        component: () => import('@/view/code/GitHubAppInstall.vue'),
+      },
+      {
         path: '/organization-alert/',
         component: RouteWrapper,
         redirect: '/organization-alert/notification',

--- a/src/router/menu.js
+++ b/src/router/menu.js
@@ -96,6 +96,11 @@ export const menuDefinition = [
           },
         ],
       },
+      {
+        title: 'GitHub App',
+        icon: 'mdi-github',
+        path: '/settings/github-app',
+      },
     ],
   },
   {

--- a/src/view/code/GitHubAppInstall.vue
+++ b/src/view/code/GitHubAppInstall.vue
@@ -1,0 +1,155 @@
+<template>
+  <div>
+    <v-container>
+      <page-header
+        icon="mdi-github"
+        icon-color="black"
+        :title="$t(`submenu['GitHub App']`)"
+      />
+
+      <v-row dense>
+        <v-col cols="12">
+          <p class="text-body-1 text-medium-emphasis mb-6">
+            {{ $t(`item['GitHub App Install Page Lead']`) }}
+          </p>
+        </v-col>
+      </v-row>
+
+      <v-row dense>
+        <v-col cols="12">
+          <v-card rounded="lg" variant="flat" class="github-app-install-card">
+            <v-card-text>
+              <div class="d-flex align-start mb-4">
+                <v-icon
+                  color="green-darken-1"
+                  icon="mdi-shield-check-outline"
+                  size="32"
+                  class="mr-4 mt-1"
+                />
+                <div>
+                  <div class="text-h5 font-weight-bold mb-2">
+                    {{ $t(`item['GitHub App Install Section Title']`) }}
+                  </div>
+                  <div class="text-body-1 text-medium-emphasis">
+                    {{ $t(`item['GitHub App Install Section Lead']`) }}
+                  </div>
+                </div>
+              </div>
+
+              <v-alert
+                class="github-app-install-owner-notice mb-5"
+                density="comfortable"
+                type="info"
+                variant="tonal"
+              >
+                <div>
+                  {{ $t(`item['GitHub App Install Owner Notice Primary']`) }}
+                </div>
+                <div>
+                  {{ $t(`item['GitHub App Install Owner Notice Secondary']`) }}
+                </div>
+              </v-alert>
+
+              <v-list class="github-app-install-list mb-6" density="compact">
+                <v-list-item
+                  v-for="item in checklist"
+                  :key="item"
+                  prepend-icon="mdi-check-circle-outline"
+                >
+                  <template v-slot:title>
+                    <span v-if="item === 'GitHub App Install Checklist After'">
+                      {{
+                        $t(
+                          `item['GitHub App Install Checklist After Before Link']`
+                        )
+                      }}
+                      <router-link :to="githubSettingListTo">
+                        {{
+                          $t(
+                            `item['GitHub App Install Checklist After Link Text']`
+                          )
+                        }}
+                      </router-link>
+                      {{
+                        $t(
+                          `item['GitHub App Install Checklist After After Link']`
+                        )
+                      }}
+                    </span>
+                    <span v-else>
+                      {{ $t(`item['` + item + `']`) }}
+                    </span>
+                  </template>
+                </v-list-item>
+              </v-list>
+
+              <div class="text-body-2 text-medium-emphasis mb-3">
+                {{ $t(`item['GitHub App Install Before Open Note']`) }}
+              </div>
+
+              <v-btn
+                color="deep-purple-lighten-1"
+                size="large"
+                :href="installURL"
+                target="_blank"
+                rel="noopener noreferrer"
+                append-icon="mdi-open-in-new"
+              >
+                {{ $t(`btn['OPEN INSTALL PAGE']`) }}
+              </v-btn>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script>
+import PageHeader from '@/component/widget/toolbar/PageHeader.vue'
+
+export default {
+  name: 'GitHubAppInstall',
+  components: {
+    PageHeader,
+  },
+  data() {
+    return {
+      installURL:
+        'https://github.com/apps/risken-code-app/installations/select_target',
+      checklist: [
+        'GitHub App Install Checklist Owner',
+        'GitHub App Install Checklist Target',
+        'GitHub App Install Checklist After',
+      ],
+    }
+  },
+  computed: {
+    githubSettingListTo() {
+      const query = {}
+      if (this.$route.query.project_id) {
+        query.project_id = this.$route.query.project_id
+      }
+      return {
+        path: '/code/github',
+        query,
+      }
+    },
+  },
+}
+</script>
+
+<style scoped>
+.github-app-install-card {
+  border: 1px solid rgb(var(--v-theme-outline-variant));
+}
+
+.github-app-install-list {
+  border: 1px solid rgb(var(--v-theme-outline-variant));
+  border-radius: 8px;
+}
+
+.github-app-install-owner-notice {
+  color: #0d47a1;
+}
+</style>


### PR DESCRIPTION
## PRの概要

GitHub App方式では、スキャン設定者が設定を進める前に、対象のGitHub Organization OwnerまたはUser本人によるAppインストールが必要です。

このPRでは、通常のGitHub設定画面とは別に、初回セットアップ用のGitHub Appインストールページを設定メニュー配下へ追加します。

### UI
<img width="1672" height="1003" alt="スクリーンショット 2026-07-08 18 39 53" src="https://github.com/user-attachments/assets/6dcc86c1-d1a2-49b1-8ff1-e4f283bca1a0" />



## 背景

### 【目的】

GitHub App方式の初回セットアップとして、Org OwnerまたはUser本人がGitHub Appインストールページへ迷わず遷移できる導線を用意することが目的です。

### 【経緯】

GitHub App方式では、RISKEN上でスキャン設定を保存・連携する前に、GitHub側で対象OrganizationまたはUserへAppをインストールしておく必要があります。

この導線を通常のGitHub設定画面に混ぜると、スキャン設定者の作業とOrg Owner向けの初回セットアップが混在します。

### 【経緯を踏まえた方針】

通常のGitHub設定画面とは分けて、設定メニュー配下にGitHub Appインストール専用ページを追加します。

ページ内では、インストールできる権限者、GitHub上で選択すべき対象、インストール後に戻るRISKEN上のGitHub設定一覧画面を案内します。

## 全体タスクにおける本PRの立ち位置

```mermaid
flowchart TD
    A["RISKEN管理者<br/>GitHub Appを用意する"] --> B["Org OwnerまたはUser本人<br/>GitHub Appをインストールする"]
    B --> C["RISKEN利用者<br/>GitHub App方式のGitHub設定を保存する"]
    C --> D["RISKEN利用者<br/>GitHub連携を実施する"]
    D --> E["RISKEN<br/>対象Repositoryをスキャンする"]

    B -.-> BStatus["今回PR<br/>インストール導線を追加"]
    C -.-> CStatus["後続PR<br/>GitHub設定画面側の導線"]
    D -.-> DStatus["backend実装済み<br/>frontend導線は後続"]
    E -.-> EStatus["既存機能<br/>実装済み"]

    B:::current
    BStatus:::current

    classDef current fill:#fff3cd,stroke:#d39e00,stroke-width:2px,color:#24292f;
```

## 修正点

| 変更点 | 内容 |
|---|---|
| GitHub Appインストールページ | `/settings/github-app` に初回セットアップ用ページを追加 |
| 設定メニュー | 設定配下に `GitHub App` メニューを追加 |
| インストール導線 | `https://github.com/apps/risken-code-app/installations/select_target` へ遷移するボタンを追加 |
| GitHub設定一覧への戻り導線 | `project_id` を維持して `/code/github?project_id=<project_id>` へ遷移するリンクを追加 |
| 日英文言 | インストール権限者、インストール後の作業、注意書きの文言を追加 |

## 重点レビューポイント

- GitHub Appインストールページを通常のGitHub設定画面とは分け、設定メニュー配下に置く導線が妥当かどうか。
- インストールURLを本番用GitHub Appの固定URLにしていることが妥当かどうか。
- インストール後に `project_id` を維持してGitHub設定一覧へ戻す導線が妥当かどうか。

## 動作確認

`pnpm exec prettier --check src/router/config.js src/router/menu.js src/view/code/GitHubAppInstall.vue src/i18n/message/ja.js src/i18n/message/en.js` を実行し、フォーマット差分がないことを確認しました。

`pnpm exec eslint src/router/config.js src/router/menu.js src/view/code/GitHubAppInstall.vue src/i18n/message/ja.js src/i18n/message/en.js` を実行し、lintエラーがないことを確認しました。

`pnpm run build` を実行し、ビルドが成功することを確認しました。

`git diff --check` を実行し、空白エラーがないことを確認しました。
