### PR TITLE
Add GitHub App setting UI

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -51,7 +51,13 @@ const en = {
     EDIT: 'EDIT',
     'Re-generate': 'Re-generate',
     DOWNLOAD_PDF: 'Download PDF',
+    'VERIFY GITHUB USER': 'LINK GITHUB',
+    RESYNC: 'RESYNC',
     'OPEN INSTALL PAGE': 'Open install page',
+  },
+  help: {
+    'GITHUB APP AUTH FLOW':
+      'To use GitHub App authentication, install the GitHub App to the target organization before running a scan. After saving, run "LINK GITHUB" and complete OAuth authorization on GitHub as the setting user.',
   },
   menu: {
     Home: 'Home',
@@ -163,13 +169,55 @@ const en = {
     'GCP ID': 'GCP ID',
     'GCP Project': 'GCP Project',
     'GCP ProjectID': 'GCP ProjectID',
+    'Auth Mode': 'Auth Mode',
     'GitHub Setting': 'GitHub Setting',
     'GitHub Setting ID': 'GitHub Setting ID',
     GitHubUser: 'GitHubUser',
-    'Gitleaks Setting': 'Gitleaks Setting',
-    'Gitleaks Status': 'Gitleaks Status',
-    'CodeScan Setting': 'CodeScan Setting',
-    'CodeScan Status': 'CodeScan Status',
+    'Installation ID': 'Installation ID',
+    'Verified GitHub User': 'Verified GitHub User',
+    'GitHub Setting User': 'Setting User (GitHub User)',
+    'Verified At': 'Verified At',
+    'Verification Status': 'Verification Status',
+    'GitHub App Status': 'GitHub App Status',
+    Unverified: 'Unverified',
+    Verified: 'Verified',
+    'Verification Failed': 'Verification Failed',
+    'GitHub App Link Success': 'Linked',
+    'GitHub App Link Failed': 'Link Failed',
+    'GitHub App Link Pending': 'GitHub Link Pending',
+    'GitHub App Link Pending Action Prefix': 'Run ',
+    'GitHub App Link Pending Action Link': 'LINK GITHUB',
+    'GitHub App Link Pending Action Suffix': '.',
+    'GitHub User Verification Pending': 'GitHub Link Pending',
+    'GitHub Setting ID Suffix': ' (GitHub Setting ID: {id})',
+    'GitHub User Verification Completed': 'GitHub linking has been completed.',
+    'GitHub User Verification Session Expired':
+      'GitHub linking could not be completed because the session expired.',
+    'GitHub User Verification Unauthorized':
+      'GitHub linking failed. Please check the RISKEN project permission.',
+    'GitHub User Verification Failed':
+      'GitHub linking failed. Please check the GitHub permission or GitHub App setting.',
+    'GitHub App Verified': 'GitHub App verification has been completed.',
+    'GitHub App Verification Failed': 'GitHub App verification failed.',
+    'GitHub App Installation Installed': 'GitHub App is installed.',
+    'GitHub App Installation Not Installed': 'GitHub App is not installed.',
+    'GitHub App Installation Check Failed':
+      'Could not check the GitHub App installation status.',
+    'GitHub App Installation Installed Message':
+      'Confirmed the GitHub App installation for {target}. Run LINK GITHUB to complete the scan setting.',
+    'GitHub App Installation Not Installed Message':
+      'The GitHub App is not installed to the target organization or user. Ask the organization administrator to confirm the installation.',
+    'GitHub App Installation Open Install Page':
+      'Open GitHub App installation page',
+    'GitHub App Installation Check Failed Message':
+      'Check the GitHub App setting or the connection to the GitHub API.',
+    'Request Failed Please Check Setting':
+      'Request failed. Please check the setting.',
+    'Unexpected Error Occurred': 'Unexpected error occurred.',
+    'Session Expired Please Sign In Again':
+      'Session expired. Please sign in again.',
+    'Repository Count': 'Repository Count',
+    'Target Repository List': 'Target Repository List',
     'GitHub App Install Page Lead':
       'This is the initial setup for an organization administrator or user owner. After installation, continue the scan setup from the GitHub setting page.',
     'GitHub App Install Section Title': 'Install GitHub App',
@@ -183,12 +231,18 @@ const en = {
       'You have owner permission for the target organization or user account.',
     'GitHub App Install Checklist Target':
       'Select the target organization or user on GitHub.',
+    'GitHub App Install Checklist After':
+      'After installation, save the GitHub App setting and run LINK GITHUB from the GitHub setting page.',
     'GitHub App Install Checklist After Before Link':
       'After installation, save the GitHub App setting and run LINK GITHUB from the ',
     'GitHub App Install Checklist After Link Text': 'GitHub setting page',
     'GitHub App Install Checklist After After Link': '.',
     'GitHub App Install Before Open Note':
       'The installation page opens on GitHub.',
+    'Gitleaks Setting': 'Gitleaks Setting',
+    'Gitleaks Status': 'Gitleaks Status',
+    'CodeScan Setting': 'CodeScan Setting',
+    'CodeScan Status': 'CodeScan Status',
     'Google Data Source': 'Google Data Source',
     'Google Data Source ID': 'Google Data Source ID',
     Keyword: 'Keyword',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -51,7 +51,13 @@ const ja = {
     EDIT: '編集',
     'Re-generate': '再生成',
     DOWNLOAD_PDF: 'PDFダウンロード',
+    'VERIFY GITHUB USER': 'GitHub連携',
+    RESYNC: '再同期',
     'OPEN INSTALL PAGE': 'インストールページを開く',
+  },
+  help: {
+    'GITHUB APP AUTH FLOW':
+      'GitHub App認証を利用するには、スキャンを実施する前に、GitHub組織のオーナーがGitHub Appを対象Organizationへインストールしてください。保存後は「GitHub連携」を実行し、GitHub上で設定者本人のOAuth認可を完了してください。',
   },
   menu: {
     Home: 'ホーム',
@@ -163,11 +169,55 @@ const ja = {
     'GCP ID': 'GCP ID',
     'GCP Project': 'GCPプロジェクト',
     'GCP ProjectID': 'GCPプロジェクトID',
+    'Auth Mode': '認証方式',
     GitHubUser: 'GitHubユーザ',
     'GitHub Setting': 'GitHub設定',
     'GitHub Setting ID': 'GitHub Setting ID',
-    'Gitleaks Setting': 'Gitleaks設定',
-    'CodeScan Setting': 'CodeScan設定',
+    'Installation ID': 'Installation ID',
+    'Verified GitHub User': '検証GitHubユーザ',
+    'GitHub Setting User': '設定者(GitHubユーザー)',
+    'Verified At': '検証日時',
+    'Verification Status': '検証ステータス',
+    'GitHub App Status': 'GitHub Appステータス',
+    Unverified: '未検証',
+    Verified: '検証済み',
+    'Verification Failed': '検証失敗',
+    'GitHub App Link Success': '連携成功',
+    'GitHub App Link Failed': '連携失敗',
+    'GitHub App Link Pending': 'GitHub連携待ち',
+    'GitHub App Link Pending Action Prefix': '',
+    'GitHub App Link Pending Action Link': 'GitHub連携',
+    'GitHub App Link Pending Action Suffix': 'を実施してください。',
+    'GitHub User Verification Pending': 'GitHub連携待ち',
+    'GitHub Setting ID Suffix': '（GitHub Setting ID: {id}）',
+    'GitHub User Verification Completed': 'GitHub連携が完了しました。',
+    'GitHub User Verification Session Expired':
+      'セッション切れのため、GitHub連携を完了できませんでした。',
+    'GitHub User Verification Unauthorized':
+      'GitHub連携に失敗しました。RISKENプロジェクトの権限を確認してください。',
+    'GitHub User Verification Failed':
+      'GitHub連携に失敗しました。GitHub側の権限またはGitHub App設定を確認してください。',
+    'GitHub App Verified': 'GitHub Appの確認が完了しました。',
+    'GitHub App Verification Failed': 'GitHub Appの確認に失敗しました。',
+    'GitHub App Installation Installed': 'GitHub Appはインストール済みです。',
+    'GitHub App Installation Not Installed': 'GitHub Appは未インストールです。',
+    'GitHub App Installation Check Failed':
+      'GitHub Appのインストール状態を確認できませんでした。',
+    'GitHub App Installation Installed Message':
+      '{target} へのGitHub Appインストールを確認しました。GitHub連携を実行すると、スキャン設定を完了できます。',
+    'GitHub App Installation Not Installed Message':
+      '対象OrganizationまたはUserにGitHub Appがインストールされていません。Organization管理者にインストール状況を確認してください。',
+    'GitHub App Installation Open Install Page':
+      'GitHub Appインストールページを開く',
+    'GitHub App Installation Check Failed Message':
+      'GitHub App設定またはGitHub APIとの通信状況を確認してください。',
+    'Request Failed Please Check Setting':
+      'リクエストに失敗しました。設定内容を確認してください。',
+    'Unexpected Error Occurred': '予期しないエラーが発生しました。',
+    'Session Expired Please Sign In Again':
+      'セッション切れです。再度サインインしてください。',
+    'Repository Count': 'リポジトリ数',
+    'Target Repository List': '対象リポジトリ一覧',
     'GitHub App Install Page Lead':
       'Organization管理者またはUserのOwnerが実施する初回セットアップです。インストール完了後にGitHub設定からスキャン設定を進められます。',
     'GitHub App Install Section Title': 'GitHub Appのインストール',
@@ -181,12 +231,16 @@ const ja = {
       '対象OrganizationまたはUserのOwner権限を持っていること',
     'GitHub App Install Checklist Target':
       'GitHub上でインストール対象のOrganizationまたはUserを選択すること',
+    'GitHub App Install Checklist After':
+      'インストール後、RISKEN上のGitHub設定画面でGitHub App方式の設定保存とGitHub連携を実施すること',
     'GitHub App Install Checklist After Before Link': 'インストール後、',
     'GitHub App Install Checklist After Link Text': 'RISKEN上のGitHub設定画面',
     'GitHub App Install Checklist After After Link':
       'でGitHub App方式の設定保存とGitHub連携を実施すること',
     'GitHub App Install Before Open Note':
       'インストールページはGitHubの画面で開きます。',
+    'Gitleaks Setting': 'Gitleaks設定',
+    'CodeScan Setting': 'CodeScan設定',
     'Google Data Source': 'Google データソース',
     'Google Data Source ID': 'Google データソースID',
     Keyword: 'キーワード',

--- a/src/mixin/api/code.js
+++ b/src/mixin/api/code.js
@@ -41,9 +41,59 @@ const code = {
           return Promise.reject(err)
         })
       if (!res.data || !res.data.data || !res.data.data.github_setting) {
-        return {}
+        return null
       }
       return res.data.data.github_setting
+    },
+    async verifyGitHubAppInstallationAPI(github_setting_id) {
+      const param = {
+        project_id: this.getCurrentProjectID(),
+        github_setting_id: github_setting_id,
+      }
+      const res = await this.$axios
+        .post('/code/verify-github-app-installation/', param)
+        .catch((err) => {
+          return Promise.reject(err)
+        })
+      if (!res.data || !res.data.data || !res.data.data.github_setting) {
+        return null
+      }
+      return res.data.data.github_setting
+    },
+    async getGitHubAppInstallationStatusAPI(github_setting_id) {
+      const query = new URLSearchParams()
+      query.set('project_id', this.getCurrentProjectID())
+      query.set('github_setting_id', github_setting_id)
+      const res = await this.$axios
+        .get('/code/github-app/installation-status/?' + query.toString())
+        .catch((err) => {
+          return Promise.reject(err)
+        })
+      if (
+        !res.data ||
+        !res.data.data ||
+        !res.data.data.github_app_installation_status
+      ) {
+        return null
+      }
+      return res.data.data.github_app_installation_status
+    },
+    async getGitHubAppOAuthStartURLAPI(github_setting_id, return_to) {
+      const query = new URLSearchParams()
+      query.set('project_id', this.getCurrentProjectID())
+      query.set('github_setting_id', github_setting_id)
+      if (return_to) {
+        query.set('return_to', return_to)
+      }
+      const res = await this.$axios
+        .get('/code/github-app/oauth-start/?' + query.toString())
+        .catch((err) => {
+          return Promise.reject(err)
+        })
+      if (!res.data || !res.data.data || !res.data.data.url) {
+        return ''
+      }
+      return res.data.data.url
     },
     async deleteGitHubSettingAPI(github_setting_id) {
       const param = {

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -102,7 +102,9 @@
               >
                 <template v-slot:[`item.type_text`]="{ item }">
                   <v-chip label variant="outlined" color="blue-darken-2">{{
-                    item.value.type_text
+                    item.value.type_text === 'Organization'
+                      ? 'Org'
+                      : item.value.type_text
                   }}</v-chip>
                 </template>
                 <template v-slot:[`item.auth_mode`]="{ item }">
@@ -612,7 +614,7 @@ export default {
     getGitHubTypeText(typeCode) {
       switch (typeCode) {
         case 1:
-          return 'Org'
+          return 'Organization'
         case 2:
           return 'User'
         default:

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -63,6 +63,19 @@
           />
         </v-row>
       </v-form>
+      <v-row v-if="githubAppOAuthResult">
+        <v-col cols="12">
+          <v-alert
+            density="compact"
+            variant="tonal"
+            :type="githubAppOAuthResult.type"
+            closable
+            @click:close="githubAppOAuthResult = null"
+          >
+            {{ githubAppOAuthResult.message }}
+          </v-alert>
+        </v-col>
+      </v-row>
       <v-row>
         <v-col cols="12">
           <v-card>
@@ -83,19 +96,47 @@
                 locale="ja-jp"
                 loading-text="Loading..."
                 no-data-text="No data."
-                class="elevation-1"
+                class="github-setting-table elevation-1"
                 item-key="diagnosis_id"
                 @click:row="handleRowClick"
               >
-                <template v-slot:[`item.avator`]>
-                  <v-avatar class="ma-3" size="48px">
-                    <v-icon color="black" size="36px" icon="mdi-github" />
-                  </v-avatar>
-                </template>
                 <template v-slot:[`item.type_text`]="{ item }">
                   <v-chip label variant="outlined" color="blue-darken-2">{{
                     item.value.type_text
                   }}</v-chip>
+                </template>
+                <template v-slot:[`item.auth_mode`]="{ item }">
+                  <v-chip label variant="outlined" color="cyan-darken-2">
+                    {{ getGitHubAuthModeText(item.value.auth_mode) }}
+                  </v-chip>
+                </template>
+                <template v-slot:[`item.verification_status`]="{ item }">
+                  <div class="github-app-status-icon">
+                    <v-icon
+                      v-if="item.value.auth_mode === 'GITHUB_APP'"
+                      :color="
+                        getGitHubVerificationColor(
+                          item.value.auth_mode,
+                          item.value.verification_status
+                        )
+                      "
+                      :icon="
+                        getGitHubVerificationIcon(
+                          item.value.verification_status
+                        )
+                      "
+                    >
+                      <v-tooltip activator="parent" location="bottom">
+                        {{
+                          getGitHubVerificationText(
+                            item.value.auth_mode,
+                            item.value.verification_status
+                          )
+                        }}
+                      </v-tooltip>
+                    </v-icon>
+                    <span v-else>-</span>
+                  </div>
                 </template>
                 <template v-slot:[`item.status_gitleaks`]="{ item }">
                   <scan-status
@@ -203,6 +244,7 @@
       :dependencyDataSourceModel="dependencyDataSourceModel"
       :codeScanDataSourceModel="codeScanDataSourceModel"
       @closeDialog="closeDialogEdit"
+      @editGitHubSetting="handleEditGitHubSettingFromDetail"
       v-on:edit-notify="handleEditFinish"
     ></setting-dialog>
 
@@ -253,6 +295,7 @@ export default {
         max_score: '',
         updated_at: '',
       },
+      githubAppOAuthResult: null,
       gitHubModel: {
         github_setting_id: '',
         code_data_source_id: '',
@@ -263,6 +306,12 @@ export default {
         target_resource: '',
         github_user: '',
         personal_access_token: '',
+        auth_mode: 'PERSONAL_ACCESS_TOKEN',
+        installation_id: '',
+        verification_status: '',
+        verified_github_user: '',
+        verified_at: '',
+        github_app_setting_repository: [],
         updated_at: '',
         gitleaksSetting: {
           repository_pattern: '',
@@ -342,23 +391,27 @@ export default {
     headers() {
       return [
         {
-          title: this.$i18n.t('item[""]'),
-          align: 'center',
-          width: '10%',
-          sortable: false,
-          key: 'avator',
-        },
-        {
-          title: this.$i18n.t('item["ID"]'),
-          align: 'start',
-          sortable: true,
-          key: 'github_setting_id',
-        },
-        {
           title: this.$i18n.t('item["Name"]'),
           align: 'start',
           sortable: true,
           key: 'name',
+        },
+        {
+          title: this.$i18n.t('item["Auth Mode"]'),
+          align: 'start',
+          sortable: true,
+          key: 'auth_mode',
+        },
+        {
+          title: this.formatStatusHeader(
+            this.$i18n.t('item["GitHub App Status"]')
+          ),
+          align: 'center',
+          cellProps: {
+            class: 'github-app-status-cell',
+          },
+          sortable: true,
+          key: 'verification_status',
         },
         {
           title: this.$i18n.t('item["Type"]'),
@@ -373,19 +426,25 @@ export default {
           key: 'target_resource',
         },
         {
-          title: this.$i18n.t('item["Gitleaks Status"]'),
+          title: this.formatStatusHeader(
+            this.$i18n.t('item["Gitleaks Status"]')
+          ),
           align: 'start',
           sortable: true,
           key: 'status_gitleaks',
         },
         {
-          title: this.$i18n.t('item["Dependency Status"]'),
+          title: this.formatStatusHeader(
+            this.$i18n.t('item["Dependency Status"]')
+          ),
           align: 'start',
           sortable: true,
           key: 'status_dependency',
         },
         {
-          title: this.$i18n.t('item["CodeScan Status"]'),
+          title: this.formatStatusHeader(
+            this.$i18n.t('item["CodeScan Status"]')
+          ),
           align: 'start',
           sortable: true,
           key: 'status_code_scan',
@@ -403,6 +462,7 @@ export default {
     this.loading = true
     await this.getDataSource()
     await this.listGitHubSetting()
+    await this.handleGitHubAppOAuthResult()
     this.loading = false
   },
   methods: {
@@ -453,6 +513,16 @@ export default {
           target_resource: github_setting.target_resource,
           github_user: github_setting.github_user,
           personal_access_token: github_setting.personal_access_token,
+          auth_mode:
+            github_setting.auth_mode == ''
+              ? 'PERSONAL_ACCESS_TOKEN'
+              : github_setting.auth_mode,
+          installation_id: github_setting.installation_id,
+          verification_status: github_setting.verification_status,
+          verified_github_user: github_setting.verified_github_user,
+          verified_at: github_setting.verified_at,
+          github_app_setting_repository:
+            github_setting.github_app_setting_repository || [],
           updated_at: github_setting.updated_at,
         }
         if (github_setting.gitleaks_setting) {
@@ -545,12 +615,150 @@ export default {
     getGitHubTypeText(typeCode) {
       switch (typeCode) {
         case 1:
-          return 'Organization'
+          return 'Org'
         case 2:
           return 'User'
         default:
           return 'Unknown' // Unknown
       }
+    },
+    getGitHubAuthModeText(authMode) {
+      switch (authMode) {
+        case 'GITHUB_APP':
+          return 'App'
+        case 'PERSONAL_ACCESS_TOKEN':
+        case '':
+        case undefined:
+        case null:
+          return 'PAT'
+        default:
+          return 'Unknown'
+      }
+    },
+    formatStatusHeader(label) {
+      return String(label)
+        .replace('ステータス', '\nステータス')
+        .replace(' Status', '\nStatus')
+    },
+    getGitHubVerificationColor(authMode, status) {
+      if (authMode !== 'GITHUB_APP') {
+        return 'grey'
+      }
+      switch (status) {
+        case 'SUCCESS':
+          return 'green'
+        case 'FAILED':
+          return 'red'
+        case 'PENDING_USER_VERIFICATION':
+        case 'PENDING':
+          return 'orange'
+        default:
+          return 'grey'
+      }
+    },
+    getGitHubVerificationText(authMode, status) {
+      if (authMode !== 'GITHUB_APP') {
+        return '-'
+      }
+      if (!status) {
+        return this.$t(`item['GitHub App Link Pending']`)
+      }
+      switch (status) {
+        case 'SUCCESS':
+          return this.$t(`item['GitHub App Link Success']`)
+        case 'FAILED':
+          return this.$t(`item['GitHub App Link Failed']`)
+        case 'PENDING_USER_VERIFICATION':
+        case 'PENDING':
+          return this.$t(`item['GitHub App Link Pending']`)
+        default:
+          return status
+      }
+    },
+    getGitHubVerificationIcon(status) {
+      switch (status) {
+        case 'SUCCESS':
+          return 'mdi-check-circle'
+        case 'FAILED':
+          return 'mdi-alert-circle'
+        case 'PENDING_USER_VERIFICATION':
+        case 'PENDING':
+        case '':
+        case undefined:
+        case null:
+          return 'mdi-clock-outline'
+        default:
+          return 'mdi-help-circle-outline'
+      }
+    },
+    async isVerifiedGitHubAppOAuthResult(githubSettingID) {
+      const settingID = Number(githubSettingID)
+      if (!Number.isInteger(settingID) || settingID <= 0) {
+        return false
+      }
+      const githubSettings = await this.listGitHubSettingAPI(settingID).catch(
+        () => {
+          return []
+        }
+      )
+      if (!githubSettings.length) {
+        return false
+      }
+      return githubSettings[0].verification_status === 'SUCCESS'
+    },
+    async handleGitHubAppOAuthResult() {
+      const result = this.$route.query.github_app_oauth
+      if (!result) {
+        return
+      }
+      const githubSettingID = this.$route.query.github_setting_id
+      const suffix = githubSettingID
+        ? this.$t(`item['GitHub Setting ID Suffix']`, { id: githubSettingID })
+        : ''
+      if (
+        result === 'success' &&
+        (await this.isVerifiedGitHubAppOAuthResult(githubSettingID))
+      ) {
+        this.githubAppOAuthResult = {
+          type: 'success',
+          message:
+            this.$t(`item['GitHub User Verification Completed']`) + suffix,
+        }
+        this.$refs.snackbar.notifySuccess(
+          this.$t(`item['GitHub App Verified']`)
+        )
+      } else if (result === 'session_expired') {
+        this.githubAppOAuthResult = {
+          type: 'warning',
+          message:
+            this.$t(`item['GitHub User Verification Session Expired']`) +
+            suffix,
+        }
+        this.$refs.snackbar.notifyError(
+          this.$t(`item['Session Expired Please Sign In Again']`)
+        )
+      } else if (result === 'unauthorized') {
+        this.githubAppOAuthResult = {
+          type: 'error',
+          message:
+            this.$t(`item['GitHub User Verification Unauthorized']`) + suffix,
+        }
+        this.$refs.snackbar.notifyError(
+          this.$t(`item['GitHub App Verification Failed']`)
+        )
+      } else {
+        this.githubAppOAuthResult = {
+          type: 'error',
+          message: this.$t(`item['GitHub User Verification Failed']`) + suffix,
+        }
+        this.$refs.snackbar.notifyError(
+          this.$t(`item['GitHub App Verification Failed']`)
+        )
+      }
+      const query = Object.assign({}, this.$route.query)
+      delete query.github_app_oauth
+      delete query.github_setting_id
+      this.$router.replace({ path: this.$route.path, query: query })
     },
     // Handler
     async handleList() {
@@ -566,7 +774,10 @@ export default {
       this.settingDialog = true
     },
     handleNewGitHubSetting() {
-      this.gitHubModel = {}
+      this.gitHubModel = {
+        auth_mode: 'PERSONAL_ACCESS_TOKEN',
+        github_app_setting_repository: [],
+      }
       this.newGitleaksSetting()
       this.newDependencySetting()
       this.newCodeScanSetting()
@@ -597,6 +808,9 @@ export default {
       this.assignDataModel(item.value)
       this.isReadOnlyForm = false
       this.settingDialog = true
+    },
+    handleEditGitHubSettingFromDetail() {
+      this.isReadOnlyForm = false
     },
     handleDeleteGitHubSetting(item) {
       this.assignDataModel(item.value)
@@ -702,3 +916,22 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.github-setting-table :deep(thead th .v-data-table-header__content) {
+  white-space: pre-line;
+}
+
+.github-app-status-icon {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.github-setting-table :deep(.github-app-status-cell) {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  text-align: center;
+}
+</style>

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -407,9 +407,6 @@ export default {
             this.$i18n.t('item["GitHub App Status"]')
           ),
           align: 'center',
-          cellProps: {
-            class: 'github-app-status-cell',
-          },
           sortable: true,
           key: 'verification_status',
         },
@@ -927,11 +924,5 @@ export default {
   display: flex;
   justify-content: center;
   width: 100%;
-}
-
-.github-setting-table :deep(.github-app-status-cell) {
-  padding-left: 0 !important;
-  padding-right: 0 !important;
-  text-align: center;
 }
 </style>

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -20,19 +20,19 @@
           <v-tab
             class="mx-0 px-0"
             :value="2"
-            :disabled="!isConfiguredGitHubSetting"
+            :disabled="!isReadyGitHubSetting"
             >{{ $t(`item['Gitleaks Setting']`) }}</v-tab
           >
           <v-tab
             class="mx-0 px-0"
             :value="3"
-            :disabled="!isConfiguredGitHubSetting"
+            :disabled="!isReadyGitHubSetting"
             >{{ $t(`item['Dependency Setting']`) }}</v-tab
           >
           <v-tab
             class="mx-0 px-0"
             :value="4"
-            :disabled="!isConfiguredGitHubSetting"
+            :disabled="!isReadyGitHubSetting"
             >{{ $t(`item['CodeScan Setting']`) }}</v-tab
           >
         </v-tabs>
@@ -123,6 +123,22 @@
                   </v-row>
                   <v-row>
                     <v-col cols="3">
+                      <v-select
+                        density="compact"
+                        required
+                        clearable
+                        v-model="gitHubSetting.auth_mode_text"
+                        :rules="gitHubForm.auth_mode.validator"
+                        :label="
+                          $t(`item['` + gitHubForm.auth_mode.label + `']`) +
+                          ' *'
+                        "
+                        :placeholder="gitHubForm.auth_mode.placeholder"
+                        :items="gitHubForm.auth_mode.list"
+                        :disabled="isReadOnly"
+                      />
+                    </v-col>
+                    <v-col cols="3">
                       <v-text-field
                         density="compact"
                         v-model="gitHubSetting.github_user"
@@ -135,7 +151,7 @@
                         :disabled="isReadOnly"
                       ></v-text-field>
                     </v-col>
-                    <v-col cols="5">
+                    <v-col cols="5" v-if="!isGitHubAppAuth">
                       <v-text-field
                         density="compact"
                         v-model="gitHubSetting.personal_access_token"
@@ -155,11 +171,178 @@
                       ></v-text-field>
                     </v-col>
                   </v-row>
+                  <v-row v-if="isGitHubAppAuth && githubAppInstallationStatus">
+                    <v-col cols="12">
+                      <v-alert
+                        density="compact"
+                        :type="githubAppInstallationStatusAlertType"
+                        :class="githubAppInstallationStatusAlertClass"
+                        variant="tonal"
+                      >
+                        <div class="font-weight-medium">
+                          {{ githubAppInstallationStatusTitle }}
+                        </div>
+                        <div>
+                          {{ githubAppInstallationStatusMessage }}
+                        </div>
+                        <div
+                          v-if="shouldShowGitHubAppInstallPageLink"
+                          class="mt-2"
+                        >
+                          <router-link
+                            class="github-app-installation-warning-link"
+                            :to="githubAppInstallPageTo"
+                          >
+                            {{
+                              $t(
+                                `item['GitHub App Installation Open Install Page']`
+                              )
+                            }}
+                          </router-link>
+                        </div>
+                      </v-alert>
+                    </v-col>
+                  </v-row>
+                  <v-row v-if="shouldShowGitHubAppLinkPendingInfo">
+                    <v-col cols="12">
+                      <v-alert density="compact" type="info" variant="tonal">
+                        <div class="font-weight-medium">
+                          <span>{{
+                            $t(`item['GitHub App Link Pending Action Prefix']`)
+                          }}</span
+                          ><a
+                            href="#"
+                            @click.prevent="$emit('editGitHubSetting')"
+                            >{{
+                              $t(`item['GitHub App Link Pending Action Link']`)
+                            }}</a
+                          ><span>{{
+                            $t(`item['GitHub App Link Pending Action Suffix']`)
+                          }}</span>
+                        </div>
+                      </v-alert>
+                    </v-col>
+                  </v-row>
+                  <v-row v-if="isGitHubAppAuth">
+                    <v-col cols="3" v-if="isConfiguredGitHubSetting">
+                      <v-list-item two-line>
+                        <v-list-item-subtitle>
+                          {{ $t(`item['GitHub App Status']`) }}
+                        </v-list-item-subtitle>
+                        <v-list-item-title>
+                          <v-chip
+                            label
+                            variant="flat"
+                            :color="
+                              getGitHubVerificationColor(
+                                gitHubSetting.verification_status
+                              )
+                            "
+                          >
+                            {{
+                              getGitHubVerificationText(
+                                gitHubSetting.verification_status
+                              )
+                            }}
+                          </v-chip>
+                        </v-list-item-title>
+                      </v-list-item>
+                    </v-col>
+                    <v-col cols="3" v-if="isConfiguredGitHubSetting">
+                      <v-list-item two-line>
+                        <v-list-item-subtitle>
+                          {{ $t(`item['GitHub Setting User']`) }}
+                        </v-list-item-subtitle>
+                        <v-list-item-title>
+                          {{ gitHubSetting.verified_github_user || '-' }}
+                        </v-list-item-title>
+                      </v-list-item>
+                    </v-col>
+                    <v-col cols="3" v-if="isGitHubAppLinked">
+                      <v-list-item two-line>
+                        <v-list-item-subtitle>
+                          {{ $t(`item['Target Repository List']`) }}
+                        </v-list-item-subtitle>
+                        <v-list-item-title>
+                          <v-btn
+                            color="cyan-darken-2"
+                            density="comfortable"
+                            size="small"
+                            variant="outlined"
+                            @click="githubAppRepositoryDialog = true"
+                          >
+                            {{ $t(`btn['CHECK']`) }}
+                          </v-btn>
+                        </v-list-item-title>
+                      </v-list-item>
+                    </v-col>
+                    <v-col cols="3" v-if="isConfiguredGitHubSetting">
+                      <v-list-item two-line>
+                        <v-list-item-subtitle>
+                          {{ $t(`item['Verified At']`) }}
+                        </v-list-item-subtitle>
+                        <v-list-item-title>
+                          {{
+                            gitHubSetting.verified_at
+                              ? formatTime(gitHubSetting.verified_at)
+                              : '-'
+                          }}
+                        </v-list-item-title>
+                      </v-list-item>
+                    </v-col>
+                  </v-row>
                 </v-form>
               </v-card-text>
               <v-card-actions>
                 <v-row>
                   <v-col class="text-right">
+                    <v-tooltip
+                      v-if="!isReadOnly && isGitHubAppAuth"
+                      location="top"
+                      max-width="360"
+                    >
+                      <template v-slot:activator="{ props }">
+                        <v-btn
+                          v-bind="props"
+                          class="mr-1"
+                          color="grey-darken-1"
+                          icon="mdi-help-circle-outline"
+                          size="small"
+                          variant="text"
+                        ></v-btn>
+                      </template>
+                      <span>
+                        {{ $t(`help['GITHUB APP AUTH FLOW']`) }}
+                      </span>
+                    </v-tooltip>
+                    <v-btn
+                      variant="outlined"
+                      color="green-darken-1"
+                      class="mr-2"
+                      @click="handleGitHubAppUserVerification"
+                      v-if="
+                        !isReadOnly &&
+                        isGitHubAppAuth &&
+                        isConfiguredGitHubSetting
+                      "
+                      :loading="loading"
+                    >
+                      {{ $t(`btn['VERIFY GITHUB USER']`) }}
+                    </v-btn>
+                    <v-btn
+                      variant="outlined"
+                      color="blue-darken-1"
+                      class="mr-2"
+                      @click="handleGitHubAppResync"
+                      v-if="
+                        !isReadOnly &&
+                        isGitHubAppAuth &&
+                        isConfiguredGitHubSetting
+                      "
+                      :loading="loading"
+                    >
+                      {{ $t(`btn['RESYNC']`) }}
+                    </v-btn>
                     <v-btn
                       variant="outlined"
                       color="blue-darken-1"
@@ -432,7 +615,7 @@
                       variant="outlined"
                       color="blue-darken-1"
                       @click="handleGitleaksEditSubmit"
-                      :disabled="!isConfiguredGitHubSetting"
+                      :disabled="!isReadyGitHubSetting"
                       :loading="loading"
                       v-else
                       >{{ $t(`btn['SAVE']`) }}
@@ -633,7 +816,7 @@
                       variant="outlined"
                       color="blue-darken-1"
                       @click="handleDependencyEditSubmit"
-                      :disabled="!isConfiguredGitHubSetting"
+                      :disabled="!isReadyGitHubSetting"
                       :loading="loading"
                       v-else
                       >{{ $t(`btn['SAVE']`) }}
@@ -864,7 +1047,7 @@
                       variant="outlined"
                       color="blue-darken-1"
                       @click="handleCodeScanEditSubmit"
-                      :disabled="!isConfiguredGitHubSetting"
+                      :disabled="!isReadyGitHubSetting"
                       :loading="loading"
                       v-else
                       >{{ $t(`btn['SAVE']`) }}
@@ -887,6 +1070,31 @@
         <!-- dependency -->
       </v-card>
     </v-dialog>
+    <v-dialog v-model="githubAppRepositoryDialog" max-width="900">
+      <v-card>
+        <v-card-title class="text-h6">
+          {{ $t(`item['Target Repository List']`) }}
+        </v-card-title>
+        <v-card-text>
+          <v-data-table
+            density="compact"
+            :headers="githubAppRepositoryHeaders"
+            :items="githubAppRepositoryItems"
+            :items-per-page="10"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            color="grey-darken-1"
+            variant="outlined"
+            @click="githubAppRepositoryDialog = false"
+          >
+            {{ $t(`btn['CANCEL']`) }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -902,11 +1110,13 @@ import mixin from '@/mixin'
 import project from '@/mixin/api/project'
 import code from '@/mixin/api/code'
 import GitleaksCache from './GitleaksCache.vue'
+import { VDataTable } from 'vuetify/labs/VDataTable'
 export default {
   name: 'SettingDialog',
   mixins: [mixin, project, code],
   components: {
     GitleaksCache,
+    VDataTable,
   },
   props: {
     isReadOnly: {
@@ -953,6 +1163,106 @@ export default {
       }
       return false
     },
+    isGitHubAppAuth() {
+      return (
+        this.getGitHubAuthModeCode(this.gitHubSetting.auth_mode_text) ===
+        'GITHUB_APP'
+      )
+    },
+    isReadyGitHubSetting() {
+      if (!this.isConfiguredGitHubSetting) {
+        return false
+      }
+      return true
+    },
+    isGitHubAppLinked() {
+      return (
+        this.isGitHubAppAuth &&
+        this.gitHubSetting.verification_status === 'SUCCESS'
+      )
+    },
+    isGitHubAppLinkPending() {
+      return (
+        this.isGitHubAppAuth &&
+        (!this.gitHubSetting.verification_status ||
+          this.gitHubSetting.verification_status ===
+            'PENDING_USER_VERIFICATION' ||
+          this.gitHubSetting.verification_status === 'PENDING')
+      )
+    },
+    shouldShowGitHubAppLinkPendingInfo() {
+      return (
+        this.isReadOnly &&
+        this.isConfiguredGitHubSetting &&
+        this.isGitHubAppLinkPending
+      )
+    },
+    githubAppRepositoryHeaders() {
+      return [
+        { title: '#', key: 'index', width: '80px' },
+        {
+          title: this.$t(`item['Repository']`),
+          key: 'repository_full_name',
+        },
+      ]
+    },
+    githubAppRepositoryItems() {
+      const repositories =
+        this.gitHubSetting.github_app_setting_repository || []
+      return repositories.map((repository, index) => ({
+        index: index + 1,
+        repository_full_name:
+          repository.repository_full_name ||
+          repository.github_repository_full_name ||
+          repository.full_name ||
+          repository.name ||
+          '-',
+      }))
+    },
+    githubAppInstallationStatusAlertType() {
+      if (!this.githubAppInstallationStatus) {
+        return 'info'
+      }
+      if (this.githubAppInstallationStatus.installed) {
+        return 'success'
+      }
+      if (this.githubAppInstallationStatus.reason === 'NOT_INSTALLED') {
+        return 'warning'
+      }
+      return 'error'
+    },
+    githubAppInstallationStatusAlertClass() {
+      if (this.githubAppInstallationStatus?.reason === 'NOT_INSTALLED') {
+        return 'github-app-installation-warning'
+      }
+      return ''
+    },
+    shouldShowGitHubAppInstallPageLink() {
+      return this.githubAppInstallationStatus?.reason === 'NOT_INSTALLED'
+    },
+    githubAppInstallPageTo() {
+      const query = {}
+      if (this.$route.query.project_id) {
+        query.project_id = this.$route.query.project_id
+      }
+      return {
+        path: '/settings/github-app',
+        query,
+      }
+    },
+    githubAppInstallationStatusTitle() {
+      return this.getGitHubAppInstallationStatusTitle(
+        this.githubAppInstallationStatus
+      )
+    },
+    githubAppInstallationStatusMessage() {
+      return this.getGitHubAppInstallationStatusMessage(
+        this.githubAppInstallationStatus
+      )
+    },
+  },
+  mounted() {
+    this.refreshGitHubAppInstallationStatusForReadOnly()
   },
   watch: {
     isEnabledGitleaks: function () {
@@ -986,7 +1296,19 @@ export default {
   data() {
     return {
       e6: 1,
-      gitHubSetting: this.gitHubModel,
+      gitHubSetting: Object.assign(
+        {
+          auth_mode: 'PERSONAL_ACCESS_TOKEN',
+          auth_mode_text: 'Personal Access Token',
+          github_app_setting_repository: [],
+        },
+        this.gitHubModel,
+        {
+          auth_mode_text: this.getGitHubAuthModeText(
+            this.gitHubModel.auth_mode
+          ),
+        }
+      ),
       gitleaksSetting: this.gitHubModel.gitleaksSetting,
       dependencySetting: this.gitHubModel.dependencySetting,
       codeScanSetting: this.gitHubModel.codeScanSetting,
@@ -997,10 +1319,25 @@ export default {
       isDeleteDependency: false,
       isDeleteCodeScan: false,
       gitleaksCacheDialog: false,
+      githubAppRepositoryDialog: false,
+      githubAppInstallationStatus: null,
       githubSettingID: 0,
       loading: false,
       gitHubForm: {
         valid: false,
+        auth_mode: {
+          label: 'Auth Mode',
+          placeholder: '-',
+          list: ['Personal Access Token', 'GitHub App'],
+          validator: [
+            (v) => !!v || 'AuthMode is required',
+            (v) =>
+              !v ||
+              v === 'Personal Access Token' ||
+              v === 'GitHub App' ||
+              'AuthMode is invalid',
+          ],
+        },
         name: {
           label: 'Name',
           placeholder: 'GitHub setting name',
@@ -1147,6 +1484,134 @@ export default {
     }
   },
   methods: {
+    getGitHubAuthModeCode(authModeText) {
+      switch (authModeText) {
+        case 'GitHub App':
+        case 'GITHUB_APP':
+          return 'GITHUB_APP'
+        case 'Personal Access Token':
+        case 'PERSONAL_ACCESS_TOKEN':
+        case '':
+        case undefined:
+        case null:
+          return 'PERSONAL_ACCESS_TOKEN'
+        default:
+          return ''
+      }
+    },
+    getGitHubAuthModeText(authModeCode) {
+      switch (authModeCode) {
+        case 'GITHUB_APP':
+          return 'GitHub App'
+        case 'PERSONAL_ACCESS_TOKEN':
+        case '':
+        case undefined:
+        case null:
+          return 'Personal Access Token'
+        default:
+          return authModeCode
+      }
+    },
+    getGitHubVerificationColor(status) {
+      switch (status) {
+        case 'SUCCESS':
+          return 'green'
+        case 'FAILED':
+          return 'red'
+        case 'PENDING_USER_VERIFICATION':
+        case 'PENDING':
+          return 'orange'
+        default:
+          return 'grey'
+      }
+    },
+    getGitHubVerificationText(status) {
+      if (!status) {
+        return this.$t(`item['GitHub App Link Pending']`)
+      }
+      switch (status) {
+        case 'SUCCESS':
+          return this.$t(`item['GitHub App Link Success']`)
+        case 'FAILED':
+          return this.$t(`item['GitHub App Link Failed']`)
+        case 'PENDING_USER_VERIFICATION':
+        case 'PENDING':
+          return this.$t(`item['GitHub App Link Pending']`)
+        default:
+          return status
+      }
+    },
+    getGitHubAppInstallationStatusTitle(status) {
+      if (!status) {
+        return ''
+      }
+      if (status.installed) {
+        return this.$t(`item['GitHub App Installation Installed']`)
+      }
+      switch (status.reason) {
+        case 'NOT_INSTALLED':
+          return this.$t(`item['GitHub App Installation Not Installed']`)
+        default:
+          return this.$t(`item['GitHub App Installation Check Failed']`)
+      }
+    },
+    getGitHubAppInstallationStatusMessage(status) {
+      if (!status) {
+        return ''
+      }
+      if (status.installed) {
+        return this.$t(`item['GitHub App Installation Installed Message']`, {
+          target: status.target_resource || this.gitHubSetting.target_resource,
+        })
+      }
+      if (status.reason === 'NOT_INSTALLED') {
+        return this.$t(`item['GitHub App Installation Not Installed Message']`)
+      }
+      return this.$t(`item['GitHub App Installation Check Failed Message']`)
+    },
+    getErrorMessage(err) {
+      if (err && err.response) {
+        return this.$t(`item['Request Failed Please Check Setting']`)
+      }
+      if (err && err.message) {
+        return err.message
+      }
+      return this.$t(`item['Unexpected Error Occurred']`)
+    },
+    isAllowedGitHubAppOAuthURL(rawURL) {
+      try {
+        const url = new URL(rawURL)
+        const allowedHosts = ['github.com']
+        const baseURL = new URL(
+          this.gitHubSetting.base_url || 'https://api.github.com'
+        )
+        if (baseURL.hostname !== 'api.github.com') {
+          allowedHosts.push(baseURL.hostname)
+        }
+        return (
+          url.protocol === 'https:' &&
+          allowedHosts.includes(url.hostname) &&
+          url.pathname === '/login/oauth/authorize'
+        )
+      } catch {
+        return false
+      }
+    },
+    applyGitHubSetting(gitHubSetting) {
+      if (!gitHubSetting || !gitHubSetting.github_setting_id) {
+        return false
+      }
+      this.gitHubSetting = Object.assign(this.gitHubSetting, gitHubSetting, {
+        auth_mode:
+          gitHubSetting.auth_mode == ''
+            ? 'PERSONAL_ACCESS_TOKEN'
+            : gitHubSetting.auth_mode,
+        auth_mode_text: this.getGitHubAuthModeText(gitHubSetting.auth_mode),
+        github_app_setting_repository:
+          gitHubSetting.github_app_setting_repository || [],
+      })
+      return true
+    },
     getStatus(setting) {
       if (!setting) {
         return 0 // datasource is not configured
@@ -1163,7 +1628,7 @@ export default {
       this.loading = true
       const github_setting = await this.listGitHubSettingAPI(github_setting_id)
         .catch((err) => {
-          this.$emit('edit-notify', '', err.response.data)
+          this.$emit('edit-notify', '', this.getErrorMessage(err))
           return
         })
         .finally(() => {
@@ -1186,7 +1651,12 @@ export default {
         base_url: this.gitHubSetting.base_url,
         target_resource: this.gitHubSetting.target_resource,
         github_user: this.gitHubSetting.github_user,
-        personal_access_token: this.gitHubSetting.personal_access_token,
+        personal_access_token: this.isGitHubAppAuth
+          ? ''
+          : this.gitHubSetting.personal_access_token,
+        auth_mode: this.getGitHubAuthModeCode(
+          this.gitHubSetting.auth_mode_text
+        ),
       }
       const gitHubSetting = await this.putGitHubSettingAPI(
         github_setting
@@ -1200,6 +1670,26 @@ export default {
         return Promise.reject(err)
       })
       return gitHubSetting
+    },
+    async refreshGitHubAppInstallationStatus() {
+      this.githubAppInstallationStatus =
+        await this.getGitHubAppInstallationStatusAPI(
+          this.gitHubSetting.github_setting_id
+        ).catch((err) => {
+          this.$emit('edit-notify', '', this.getErrorMessage(err))
+          return null
+        })
+    },
+    async refreshGitHubAppInstallationStatusForReadOnly() {
+      if (
+        !this.isReadOnly ||
+        !this.isConfiguredGitHubSetting ||
+        !this.isGitHubAppAuth ||
+        this.gitHubSetting.verification_status !== 'FAILED'
+      ) {
+        return
+      }
+      await this.refreshGitHubAppInstallationStatus()
     },
     async editGitleaksSetting(gitHubSettingID) {
       if (this.isDeleteGitleaks) {
@@ -1305,16 +1795,75 @@ export default {
         return
       }
       this.loading = true
-      const gitHubSetting = await this.editGitHubSetting()
-        .catch((err) => {
-          this.$emit('edit-notify', err)
+      try {
+        const gitHubSetting = await this.editGitHubSetting().catch((err) => {
+          this.$emit('edit-notify', '', this.getErrorMessage(err))
+          return null
+        })
+        if (gitHubSetting === null) {
           return
+        }
+        if (!this.applyGitHubSetting(gitHubSetting)) {
+          this.$emit('edit-notify', '', 'GitHub setting response is invalid.')
+          return
+        }
+        if (this.isGitHubAppAuth) {
+          await this.refreshGitHubAppInstallationStatus()
+        }
+        this.e6 = 2
+      } finally {
+        this.loading = false
+      }
+    },
+    async handleGitHubAppUserVerification() {
+      this.loading = true
+      const returnTo = this.buildGitHubAppOAuthReturnTo()
+      const oauthURL = await this.getGitHubAppOAuthStartURLAPI(
+        this.gitHubSetting.github_setting_id,
+        returnTo
+      )
+        .catch((err) => {
+          this.$emit('edit-notify', '', this.getErrorMessage(err))
+          return ''
         })
         .finally(() => {
           this.loading = false
         })
-      this.gitHubSetting.github_setting_id = gitHubSetting.github_setting_id
-      this.e6 = 2
+      if (!oauthURL) {
+        return
+      }
+      if (!this.isAllowedGitHubAppOAuthURL(oauthURL)) {
+        this.$emit('edit-notify', '', 'GitHub App OAuth URL is invalid.')
+        return
+      }
+      window.location.href = oauthURL
+    },
+    buildGitHubAppOAuthReturnTo() {
+      const query = new URLSearchParams()
+      query.set('project_id', this.$route.query.project_id)
+      query.set('github_setting_id', this.gitHubSetting.github_setting_id)
+      return `${this.$route.path}?${query.toString()}`
+    },
+    async handleGitHubAppResync() {
+      this.loading = true
+      const gitHubSetting = await this.verifyGitHubAppInstallationAPI(
+        this.gitHubSetting.github_setting_id
+      )
+        .catch((err) => {
+          this.$emit('edit-notify', '', this.getErrorMessage(err))
+          return null
+        })
+        .finally(() => {
+          this.loading = false
+        })
+      if (gitHubSetting === null) {
+        return
+      }
+      if (!this.applyGitHubSetting(gitHubSetting)) {
+        this.$emit('edit-notify', '', 'GitHub setting response is invalid.')
+        return
+      }
+      this.$emit('edit-notify', 'Success: Resynced GitHub App repositories.')
     },
     async handleGitleaksEditSubmit() {
       if (this.isEnabledGitleaks && !this.$refs.formGitleaks.validate()) {
@@ -1471,5 +2020,17 @@ export default {
 <style>
 .v-tab {
   text-transform: none !important;
+}
+.github-app-installation-warning {
+  background-color: #fff4d6 !important;
+  color: #4d3600 !important;
+}
+.github-app-installation-warning .v-alert__prepend {
+  color: #8a6100 !important;
+}
+.github-app-installation-warning-link {
+  color: #6b4900;
+  font-weight: 600;
+  text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
## PRの概要

スキャン設定者がGitHub App方式で設定保存、インストール状態確認、GitHub連携、対象Repository確認まで進められるように、GitHub設定画面側の導線を追加します。

バックエンド側ではGitHub Appのインストール状態確認、GitHub連携、Repository同期の処理が実装済みのため、このPRではそれらの結果をWeb画面上で確認・操作できる形に接続します。

## UI
### 設定一覧画面
ステータス：上から
- 連携成功(Appがインストールされた状態で、OAuth認可も完了時)
- ステータスなし(PATモード時)
- GitHub連携待ち(Appがインストールされた状態でOAuth認可未完了時)
- 連携失敗(Appが未インストール等で検証に失敗時)
<img width="1657" height="925" alt="スクリーンショット 2026-07-09 17 54 49" src="https://github.com/user-attachments/assets/f9e22c3c-1f5b-45e0-9d68-ae2338fc6928" />

### 詳細画面
- 連携成功
<img width="1178" height="603" alt="スクリーンショット 2026-07-09 17 55 07" src="https://github.com/user-attachments/assets/86dd0011-f8f2-4b73-836a-5e1ab867e5b7" />

- GitHub連携待ち(infoに出てくるリンクをクリックすると、再度GitHub連携ボタンのページに遷移)
<img width="1186" height="664" alt="スクリーンショット 2026-07-09 17 55 19" src="https://github.com/user-attachments/assets/5a20564a-acbc-4789-ad89-9e6521892716" />

<img width="1045" height="594" alt="スクリーンショット 2026-07-09 18 49 37" src="https://github.com/user-attachments/assets/1d88d5cb-9fe1-4572-af31-b8942109f4f5" />


- 連携失敗(App未インストール時は警告)
<img width="1180" height="701" alt="スクリーンショット 2026-07-09 17 55 36" src="https://github.com/user-attachments/assets/60b7567e-29a7-4f5c-997b-9e66f3ee7516" />


## 背景

### 【目的】

GitHub App方式のコードスキャン設定において、設定者がRISKEN上の画面だけで設定保存後の状態確認、GitHub連携、対象Repository確認まで進められるようにすることが目的です。

### 【経緯】

GitHub App方式では、PAT方式と異なり、GitHub Appのインストール状態と設定者本人のGitHub連携状態を区別して扱う必要があります。

既存の設定画面では、GitHub App方式に固有のステータスや次に必要な操作が画面上で分かりづらく、設定者がどの時点でスキャン設定を完了できるのか判断しにくい状態でした。

### 【経緯を踏まえた方針】

通常のGitHub設定画面にGitHub App方式の状態表示と操作導線を追加し、設定保存後にインストール状態確認、GitHub連携待ち、連携成功後の対象Repository確認へ進める構成にします。

PAT方式の既存フローは維持しつつ、GitHub App方式の場合だけ必要な表示・操作を出し分けます。

## 全体タスクにおける本PRの立ち位置

```mermaid
flowchart TD
    A["RISKEN管理者<br/>GitHub Appを用意する"] --> B["Org管理者またはUser本人<br/>GitHub Appをインストールする"]
    B --> C["RISKEN設定者<br/>GitHub App方式で設定を保存する"]
    C --> D["RISKEN<br/>GitHub Appのインストール状態を確認する"]
    D --> E["RISKEN設定者<br/>GitHub連携を実施する"]
    E --> F["RISKEN<br/>対象Repositoryを確認できるようにする"]
    F --> G["RISKEN<br/>定期的にコードスキャンを実行する"]

    A -.-> AStatus["実装対象外<br/>運用作業"]
    B -.-> BStatus["実装済み<br/>管理画面導線"]
    C -.-> CStatus["今回PR<br/>設定画面導線"]
    D -.-> DStatus["今回PR<br/>保存後の状態表示"]
    E -.-> EStatus["今回PR<br/>GitHub連携導線"]
    F -.-> FStatus["今回PR<br/>Repository一覧表示"]
    G -.-> GStatus["backend実装済み"]

    C:::current
    D:::current
    E:::current
    F:::current
    CStatus:::current
    DStatus:::current
    EStatus:::current
    FStatus:::current

    classDef current fill:#fff3cd,stroke:#d39e00,stroke-width:2px,color:#24292f;
```

## 修正点

| 変更点 | 内容 |
|---|---|
| GitHub設定一覧 | 認証方式、GitHub Appステータス、タイプをGitHub App方式向けに表示する |
| GitHub設定フォーム | PAT方式とGitHub App方式を選択できるようにし、GitHub App方式ではPAT入力を非表示にする |
| 保存後の状態確認 | GitHub App方式の設定保存後にインストール状態確認APIを呼び、結果に応じて警告または次の導線を表示する |
| GitHub連携導線 | GitHub連携待ちの場合に、詳細画面からGitHub連携を実行できるようにする |
| 対象Repository確認 | 連携成功後に、同期済みRepository一覧をダイアログで確認できるようにする |
| エラー処理 | APIレスポンスがnullまたは想定外構造の場合に、UI状態がPAT表示へ崩れないようにする |

## 重点レビューポイント

- GitHub App方式とPAT方式の画面表示・保存後遷移が混在しても、既存のPAT設定フローを壊していないか。
- GitHub OAuth開始URLの検証や、APIレスポンスがnullの場合の扱いが安全側に倒れているか。
- GitHub Appステータス、GitHub連携待ち、未インストール警告の表示が、設定者に次の操作を誤認させないか。
- 対象Repository一覧の表示が、バックエンドで同期済みのRepository情報をそのまま確認する用途として過不足ないか。

## 動作確認

- `pnpm exec prettier --check src/view/code/SettingDialog.vue src/i18n/message/en.js src/i18n/message/ja.js` を実行し、フォーマット差分がないことを確認。
- `pnpm exec eslint src/view/code/SettingDialog.vue src/i18n/message/en.js src/i18n/message/ja.js` を実行し、lintエラーがないことを確認。
- `make build` を実行し、Webイメージのビルドが成功することを確認。
- ローカルPodへ反映し、GitHub App方式の設定一覧、詳細画面、GitHub連携待ちinfo、リンク押下で編集状態へ遷移することを画面確認。
