### PR TITLE
GitHub App連携失敗時の再連携導線を改善

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -52,6 +52,7 @@ const en = {
     'Re-generate': 'Re-generate',
     DOWNLOAD_PDF: 'Download PDF',
     'VERIFY GITHUB USER': 'LINK GITHUB',
+    'GO TO GITHUB LINK': 'PROCEED TO GITHUB LINK',
     RESYNC: 'RESYNC',
     'OPEN INSTALL PAGE': 'Open install page',
   },

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -52,6 +52,7 @@ const ja = {
     'Re-generate': '再生成',
     DOWNLOAD_PDF: 'PDFダウンロード',
     'VERIFY GITHUB USER': 'GitHub連携',
+    'GO TO GITHUB LINK': 'GitHub連携へ進む',
     RESYNC: '再同期',
     'OPEN INSTALL PAGE': 'インストールページを開く',
   },

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -308,7 +308,7 @@ export default {
         target_resource: '',
         github_user: '',
         personal_access_token: '',
-        auth_mode: 'PERSONAL_ACCESS_TOKEN',
+        auth_mode: 'GITHUB_APP',
         installation_id: '',
         verification_status: '',
         verified_github_user: '',
@@ -780,7 +780,7 @@ export default {
     },
     handleNewGitHubSetting() {
       this.gitHubModel = {
-        auth_mode: 'PERSONAL_ACCESS_TOKEN',
+        auth_mode: 'GITHUB_APP',
         github_app_setting_repository: [],
       }
       this.newGitleaksSetting()

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -393,6 +393,12 @@ export default {
     headers() {
       return [
         {
+          title: this.$i18n.t('item["ID"]'),
+          align: 'start',
+          sortable: true,
+          key: 'github_setting_id',
+        },
+        {
           title: this.$i18n.t('item["Name"]'),
           align: 'start',
           sortable: true,
@@ -614,7 +620,7 @@ export default {
     getGitHubTypeText(typeCode) {
       switch (typeCode) {
         case 1:
-          return 'Organization'
+          return 'Org'
         case 2:
           return 'User'
         default:
@@ -917,6 +923,11 @@ export default {
 </script>
 
 <style scoped>
+.github-setting-table :deep(th),
+.github-setting-table :deep(td) {
+  font-size: 12px;
+}
+
 .github-setting-table :deep(thead th .v-data-table-header__content) {
   white-space: pre-line;
 }

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -620,7 +620,7 @@ export default {
     getGitHubTypeText(typeCode) {
       switch (typeCode) {
         case 1:
-          return 'Org'
+          return 'Organization'
         case 2:
           return 'User'
         default:

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -138,7 +138,7 @@
                         :disabled="isReadOnly"
                       />
                     </v-col>
-                    <v-col cols="3">
+                    <v-col cols="3" v-if="!isGitHubAppAuth">
                       <v-text-field
                         density="compact"
                         v-model="gitHubSetting.github_user"

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -200,6 +200,14 @@
                             }}
                           </router-link>
                         </div>
+                        <div v-if="shouldShowGitHubAppLink" class="mt-2">
+                          <a
+                            href="#"
+                            @click.prevent="handleGitHubAppUserVerification"
+                          >
+                            {{ $t(`btn['VERIFY GITHUB USER']`) }}
+                          </a>
+                        </div>
                       </v-alert>
                     </v-col>
                   </v-row>
@@ -1240,6 +1248,12 @@ export default {
     shouldShowGitHubAppInstallPageLink() {
       return this.githubAppInstallationStatus?.reason === 'NOT_INSTALLED'
     },
+    shouldShowGitHubAppLink() {
+      return (
+        this.githubAppInstallationStatus?.installed &&
+        this.gitHubSetting.verification_status !== 'SUCCESS'
+      )
+    },
     githubAppInstallPageTo() {
       const query = {}
       if (this.$route.query.project_id) {
@@ -1921,6 +1935,10 @@ export default {
         this.codeScanSetting = codeScanSetting
       }
       this.$emit('edit-notify', 'Success: Updated.')
+      if (this.isGitHubAppAuth) {
+        this.e6 = 1
+        return
+      }
       this.$emit('closeDialog')
     },
 

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -355,7 +355,7 @@
                       variant="outlined"
                       color="blue-darken-1"
                       @click="handleGitHubEditSubmit"
-                      v-if="!isReadOnly"
+                      v-if="!isReadOnly && !hasCompletedGitHubAppSettingFlow"
                       :loading="loading"
                     >
                       {{ $t(`btn['SAVE']`) }}
@@ -1332,6 +1332,7 @@ export default {
       isDeleteGitleaks: false,
       isDeleteDependency: false,
       isDeleteCodeScan: false,
+      hasCompletedGitHubAppSettingFlow: false,
       gitleaksCacheDialog: false,
       githubAppRepositoryDialog: false,
       githubAppInstallationStatus: null,
@@ -1957,6 +1958,7 @@ export default {
       }
       this.$emit('edit-notify', 'Success: Updated.')
       if (this.isGitHubAppAuth) {
+        this.hasCompletedGitHubAppSettingFlow = true
         this.e6 = 1
         return
       }

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -205,7 +205,7 @@
                             href="#"
                             @click.prevent="handleGitHubAppLinkFromDetail"
                           >
-                            {{ $t(`btn['VERIFY GITHUB USER']`) }}
+                            {{ $t(`btn['GO TO GITHUB LINK']`) }}
                           </a>
                         </div>
                       </v-alert>
@@ -1312,8 +1312,8 @@ export default {
       e6: 1,
       gitHubSetting: Object.assign(
         {
-          auth_mode: 'PERSONAL_ACCESS_TOKEN',
-          auth_mode_text: 'Personal Access Token',
+          auth_mode: 'GITHUB_APP',
+          auth_mode_text: 'GitHub App',
           github_app_setting_repository: [],
         },
         this.gitHubModel,

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -203,7 +203,7 @@
                         <div v-if="shouldShowGitHubAppLink" class="mt-2">
                           <a
                             href="#"
-                            @click.prevent="handleGitHubAppUserVerification"
+                            @click.prevent="handleGitHubAppLinkFromDetail"
                           >
                             {{ $t(`btn['VERIFY GITHUB USER']`) }}
                           </a>
@@ -1851,6 +1851,27 @@ export default {
         return
       }
       window.location.href = oauthURL
+    },
+    async handleGitHubAppLinkFromDetail() {
+      this.loading = true
+      const gitHubSetting = await this.verifyGitHubAppInstallationAPI(
+        this.gitHubSetting.github_setting_id
+      )
+        .catch((err) => {
+          this.$emit('edit-notify', '', this.getErrorMessage(err))
+          return null
+        })
+        .finally(() => {
+          this.loading = false
+        })
+      if (gitHubSetting === null) {
+        return
+      }
+      if (!this.applyGitHubSetting(gitHubSetting)) {
+        this.$emit('edit-notify', '', 'GitHub setting response is invalid.')
+        return
+      }
+      this.$emit('editGitHubSetting')
     },
     buildGitHubAppOAuthReturnTo() {
       const query = new URLSearchParams()


### PR DESCRIPTION
## PRの概要

GitHub Appがインストール済みで連携が完了していない場合に、GitHub設定の詳細画面からインストール状態を再検証し、GitHub連携を行う設定画面へ進める導線を追加します。

あわせて、GitHub設定一覧の最左列にSetting IDを表示し、タイプ名の短縮とテーブル文字サイズの調整によって一覧の視認性を改善します。GitHub App方式の設定保存後はダイアログを閉じず、GitHub連携へ続けて進めるようにします。

## 背景

### 【目的】

GitHub Appの連携失敗後に利用者が詳細画面から再連携できるようにし、GitHub設定一覧の識別性と視認性を改善するためです。

### 【経緯】

ステージング環境を操作した際、GitHub Appがインストール済みでも、ステータスが「連携失敗」の場合は詳細画面に「GitHub連携」への導線が表示されないことが判明しました。

また、GitHub設定一覧ではSetting IDが表示されておらず、ステータス列を含む一覧の見出しが窮屈に表示されていました。

### 【経緯を踏まえた方針】

GitHub Appがインストール済みかつ連携成功前の場合に「GitHub連携」リンクを表示します。リンク押下時はインストール状態を再検証して設定画面へ切り替え、OAuth連携は設定画面内の「GitHub連携」ボタンから明示的に実行します。

一覧の最左列にはIDを追加し、Organization表記の短縮とGitHub設定テーブル限定の文字サイズ調整によって、他画面へ影響させず表示を整えます。

## 修正点

| 変更点 | 内容 |
|---|---|
| 再連携導線 | GitHub Appがインストール済みかつ連携成功前の場合に「GitHub連携」リンクを表示し、インストール状態の再検証後に設定画面へ切り替え |
| 設定保存後の遷移 | GitHub App方式では設定ダイアログを維持し、連携操作へ続けて進めるよう変更 |
| ID表示 | GitHub設定一覧の最左列にSetting IDを追加 |
| 一覧レイアウト | OrganizationをOrgへ短縮し、テーブルの文字サイズを12pxへ調整 |

## 重点レビューポイント

- GitHub Appがインストール済みで連携未完了の場合だけ、GitHub連携への導線が表示されるかどうか。
- 詳細画面のリンク押下ではOAuthを開始せず、インストール状態の再検証後に設定画面へ切り替わるかどうか。
- 連携成功済みやGitHub App未インストール時の既存導線へ影響していないかどうか。
- GitHub App方式の保存後にダイアログを維持する挙動が、後続のGitHub連携フローとして妥当かどうか。
- ID列と文字サイズの変更により、PAT方式を含む既存設定でも一覧が崩れず表示されるかどうか。

## 動作確認

PrettierとESLintを実行し、コードの整形および静的検査が成功することを確認しました。

DockerでWebイメージをビルドし、Docker Desktop KubernetesのWeb Podへ反映できることを確認しました。

ローカルRISKENをブラウザで操作し、GitHub設定一覧のID列、ステータス表示、文字サイズ、およびGitHub設定詳細の状態別案内が表示されることを確認しました。

