### PR TITLE
PAT認証方式ラベルの折り返しを防止

### DIFF
--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -122,7 +122,7 @@
                     </v-col>
                   </v-row>
                   <v-row>
-                    <v-col cols="4">
+                    <v-col cols="3">
                       <v-select
                         :class="{
                           'personal-access-token-auth-mode':

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -122,7 +122,7 @@
                     </v-col>
                   </v-row>
                   <v-row>
-                    <v-col cols="3">
+                    <v-col cols="4">
                       <v-select
                         density="compact"
                         required

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -124,6 +124,11 @@
                   <v-row>
                     <v-col cols="4">
                       <v-select
+                        :class="{
+                          'personal-access-token-auth-mode':
+                            gitHubSetting.auth_mode_text ===
+                            'Personal Access Token',
+                        }"
                         density="compact"
                         required
                         clearable
@@ -2073,5 +2078,9 @@ export default {
   color: #6b4900;
   font-weight: 600;
   text-decoration: underline;
+}
+.personal-access-token-auth-mode .v-select__selection-text {
+  font-size: 14px;
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
## PRの概要

GitHub設定で認証方式に Personal Access Token を選択した際、選択ボックス内のラベルが折り返されていたため、認証方式欄を12カラム中3カラムから4カラムへ広げました。

PAT入力時の行全体を12カラムに収めたまま、既存の文字サイズを維持して一行表示できるようにします。

## レビュー観点例

- [ ] Personal Access Token が認証方式欄で一行表示される点
- [ ] PAT選択時の認証方式・GitHubユーザ・トークン欄が合計12カラムに収まる点
- [ ] GitHub App選択時の既存レイアウトに不要な影響がない点