### PR TITLE
詳細画面のGitHub連携前にインストール状態を再確認

### DIFF
--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -217,7 +217,7 @@
                           }}</span
                           ><a
                             href="#"
-                            @click.prevent="$emit('editGitHubSetting')"
+                            @click.prevent="handleGitHubAppLinkFromDetail"
                             >{{
                               $t(`item['GitHub App Link Pending Action Link']`)
                             }}</a
@@ -1841,6 +1841,27 @@ export default {
         return
       }
       window.location.href = oauthURL
+    },
+    async handleGitHubAppLinkFromDetail() {
+      this.loading = true
+      const gitHubSetting = await this.verifyGitHubAppInstallationAPI(
+        this.gitHubSetting.github_setting_id
+      )
+        .catch((err) => {
+          this.$emit('edit-notify', '', this.getErrorMessage(err))
+          return null
+        })
+        .finally(() => {
+          this.loading = false
+        })
+      if (gitHubSetting === null) {
+        return
+      }
+      if (!this.applyGitHubSetting(gitHubSetting)) {
+        this.$emit('edit-notify', '', 'GitHub setting response is invalid.')
+        return
+      }
+      this.$emit('editGitHubSetting')
     },
     buildGitHubAppOAuthReturnTo() {
       const query = new URLSearchParams()


### PR DESCRIPTION
## PRの概要

GitHub連携待ちの詳細画面から編集フローへ進む際、最新のGitHub Appインストール状態を反映してから画面を切り替える必要があるため、リンククリック時の再確認処理を復活しました。

詳細画面の「GitHub連携」リンクをクリックすると、インストール状態をAPIで再確認し、取得したGitHub設定を画面モデルへ反映した後に `editGitHubSetting` イベントを発火します。APIエラーまたは不正なレスポンスの場合は編集フローへ進みません。

## レビュー観点例

- [ ] 詳細画面のリンククリック時にインストール状態を再確認する点
- [ ] API取得結果を画面モデルへ反映してから編集イベントを発火する点
- [ ] APIエラーまたは不正レスポンス時に編集画面へ遷移しない点
- [ ] 編集画面側の削除済みリンクを復活させていない点