### PR TITLE
GitHub設定一覧のカラム表示を簡潔化

### DIFF
--- a/src/i18n/message/en.js
+++ b/src/i18n/message/en.js
@@ -170,6 +170,7 @@ const en = {
     'GCP Project': 'GCP Project',
     'GCP ProjectID': 'GCP ProjectID',
     'Auth Mode': 'Auth Mode',
+    Auth: 'Auth',
     'GitHub Setting': 'GitHub Setting',
     'GitHub Setting ID': 'GitHub Setting ID',
     GitHubUser: 'GitHubUser',

--- a/src/i18n/message/ja.js
+++ b/src/i18n/message/ja.js
@@ -170,6 +170,7 @@ const ja = {
     'GCP Project': 'GCPプロジェクト',
     'GCP ProjectID': 'GCPプロジェクトID',
     'Auth Mode': '認証方式',
+    Auth: '認証',
     GitHubUser: 'GitHubユーザ',
     'GitHub Setting': 'GitHub設定',
     'GitHub Setting ID': 'GitHub Setting ID',

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -407,7 +407,7 @@ export default {
           key: 'name',
         },
         {
-          title: this.$i18n.t('item["Auth Mode"]'),
+          title: this.$i18n.t('item["Auth"]'),
           align: 'start',
           sortable: true,
           key: 'auth_mode',

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -101,13 +101,19 @@
                 @click:row="handleRowClick"
               >
                 <template v-slot:[`item.type_text`]="{ item }">
-                  <v-chip label variant="outlined" color="blue-darken-2">{{
-                    item.value.type_text === 'Organization'
-                      ? 'O'
-                      : item.value.type_text === 'User'
-                      ? 'U'
-                      : item.value.type_text
-                  }}</v-chip>
+                  <v-tooltip :text="item.value.type_text" location="top">
+                    <template v-slot:activator="{ props }">
+                      <v-icon
+                        v-bind="props"
+                        color="blue-darken-2"
+                        :icon="
+                          item.value.type_text === 'Organization'
+                            ? 'mdi-domain'
+                            : 'mdi-account'
+                        "
+                      ></v-icon>
+                    </template>
+                  </v-tooltip>
                 </template>
                 <template v-slot:[`item.auth_mode`]="{ item }">
                   <v-chip label variant="outlined" color="cyan-darken-2">

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -103,7 +103,9 @@
                 <template v-slot:[`item.type_text`]="{ item }">
                   <v-chip label variant="outlined" color="blue-darken-2">{{
                     item.value.type_text === 'Organization'
-                      ? 'Org'
+                      ? 'O'
+                      : item.value.type_text === 'User'
+                      ? 'U'
                       : item.value.type_text
                   }}</v-chip>
                 </template>


### PR DESCRIPTION
## PRの概要

GitHub設定一覧で情報をコンパクトに確認できるようにするため、タイプ表示を Organization は `O`、User は `U` の1文字へ短縮しました。

また、一覧の「認証方式」カラムを「認証」へ変更しました。編集画面の「認証方式」は従来の表記を維持するため、一覧専用の翻訳キーを追加しています。

## レビュー観点例

- [ ] Organization と User がそれぞれ `O` と `U` で表示される点
- [ ] 未知のタイプ値は従来どおり元の値を表示する点
- [ ] 一覧だけが「認証」に変わり、編集画面の「認証方式」には影響しない点
- [ ] 日本語と英語でカラム名が適切に表示される点