### PR TITLE
GitHub設定一覧の各カラムを中央寄せに統一

### DIFF
--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -402,19 +402,19 @@ export default {
       return [
         {
           title: this.$i18n.t('item["ID"]'),
-          align: 'start',
+          align: 'center',
           sortable: true,
           key: 'github_setting_id',
         },
         {
           title: this.$i18n.t('item["Name"]'),
-          align: 'start',
+          align: 'center',
           sortable: true,
           key: 'name',
         },
         {
           title: this.$i18n.t('item["Auth"]'),
-          align: 'start',
+          align: 'center',
           sortable: true,
           key: 'auth_mode',
         },
@@ -428,13 +428,13 @@ export default {
         },
         {
           title: this.$i18n.t('item["Type"]'),
-          align: 'start',
+          align: 'center',
           sortable: true,
           key: 'type_text',
         },
         {
           title: this.$i18n.t('item["Target"]'),
-          align: 'start',
+          align: 'center',
           sortable: true,
           key: 'target_resource',
         },
@@ -442,7 +442,7 @@ export default {
           title: this.formatStatusHeader(
             this.$i18n.t('item["Gitleaks Status"]')
           ),
-          align: 'start',
+          align: 'center',
           sortable: true,
           key: 'status_gitleaks',
         },
@@ -450,7 +450,7 @@ export default {
           title: this.formatStatusHeader(
             this.$i18n.t('item["Dependency Status"]')
           ),
-          align: 'start',
+          align: 'center',
           sortable: true,
           key: 'status_dependency',
         },
@@ -458,7 +458,7 @@ export default {
           title: this.formatStatusHeader(
             this.$i18n.t('item["CodeScan Status"]')
           ),
-          align: 'start',
+          align: 'center',
           sortable: true,
           key: 'status_code_scan',
         },

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -425,6 +425,7 @@ export default {
           align: 'center',
           sortable: true,
           key: 'verification_status',
+          headerProps: { class: 'status-split-header' },
         },
         {
           title: this.$i18n.t('item["Type"]'),
@@ -445,6 +446,7 @@ export default {
           align: 'center',
           sortable: true,
           key: 'status_gitleaks',
+          headerProps: { class: 'status-split-header' },
         },
         {
           title: this.formatStatusHeader(
@@ -453,6 +455,7 @@ export default {
           align: 'center',
           sortable: true,
           key: 'status_dependency',
+          headerProps: { class: 'status-split-header' },
         },
         {
           title: this.formatStatusHeader(
@@ -461,6 +464,7 @@ export default {
           align: 'center',
           sortable: true,
           key: 'status_code_scan',
+          headerProps: { class: 'status-split-header' },
         },
         {
           title: this.$i18n.t('item["Action"]'),
@@ -936,8 +940,17 @@ export default {
   font-size: 12px;
 }
 
-.github-setting-table :deep(thead th .v-data-table-header__content) {
-  white-space: pre-line;
+.github-setting-table :deep(thead th) {
+  white-space: nowrap;
+}
+
+.github-setting-table :deep(thead th.status-split-header) {
+  white-space: normal;
+}
+
+.github-setting-table
+  :deep(thead th.status-split-header .v-data-table-header__content) {
+  white-space: pre;
 }
 
 .github-app-status-icon {


### PR DESCRIPTION
## PRの概要

GitHub設定一覧の情報を列ごとに見比べやすくするため、ID、名前、認証、タイプ、ターゲット、各スキャンステータスを含む全カラムの配置を中央寄せに統一しました。

表示位置のみの変更であり、ソート、値の取得、保存処理には影響しません。

## レビュー観点例

- [ ] 全カラムのヘッダーとセルが中央寄せで表示される点
- [ ] 長いターゲット名でも内容の視認性が保たれる点
- [ ] ソートや行クリックなど既存のテーブル操作に影響しない点