### PR TITLE
GitHub設定一覧のステータスをアイコン表示に変更

### DIFF
--- a/src/component/widget/datasource/Status.vue
+++ b/src/component/widget/datasource/Status.vue
@@ -1,6 +1,33 @@
 <template>
+  <template v-if="iconOnly">
+    <v-tooltip
+      :text="status ? getDataSourceStatusText(status) : 'Disabled'"
+      location="top"
+    >
+      <template v-slot:activator="{ props }">
+        <v-progress-circular
+          v-if="isInProgressDataSourceStatus(status)"
+          v-bind="props"
+          indeterminate
+          size="24"
+          width="3"
+          color="cyan"
+        />
+        <v-icon
+          v-else
+          v-bind="props"
+          :color="status ? getDataSourceStatusColor(status) : 'grey'"
+          :icon="
+            status
+              ? getDataSourceStatusIcon(status)
+              : 'mdi-minus-circle-outline'
+          "
+        />
+      </template>
+    </v-tooltip>
+  </template>
   <v-chip
-    v-if="true"
+    v-else
     :color="getDataSourceStatusColor(status)"
     variant="flat"
     class="text-white"
@@ -18,7 +45,6 @@
     }}</v-icon>
     {{ getDataSourceStatusText(status) }}
   </v-chip>
-  <v-chip v-else color="grey" variant="flat">Not configured</v-chip>
 </template>
 
 <script>
@@ -27,6 +53,10 @@ export default {
   mixins: [mixin],
   name: 'DataSourceStatus',
   props: {
+    iconOnly: {
+      type: Boolean,
+      default: false,
+    },
     status: {
       type: Number,
       default: 0,

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -122,55 +122,53 @@
                 </template>
                 <template v-slot:[`item.verification_status`]="{ item }">
                   <div class="github-app-status-icon">
-                    <v-icon
+                    <v-tooltip
                       v-if="item.value.auth_mode === 'GITHUB_APP'"
-                      :color="
-                        getGitHubVerificationColor(
+                      :text="
+                        getGitHubVerificationText(
                           item.value.auth_mode,
                           item.value.verification_status
                         )
                       "
-                      :icon="
-                        getGitHubVerificationIcon(
-                          item.value.verification_status
-                        )
-                      "
+                      location="top"
                     >
-                      <v-tooltip activator="parent" location="bottom">
-                        {{
-                          getGitHubVerificationText(
-                            item.value.auth_mode,
-                            item.value.verification_status
-                          )
-                        }}
-                      </v-tooltip>
-                    </v-icon>
+                      <template v-slot:activator="{ props }">
+                        <v-icon
+                          v-bind="props"
+                          :color="
+                            getGitHubVerificationColor(
+                              item.value.auth_mode,
+                              item.value.verification_status
+                            )
+                          "
+                          :icon="
+                            getGitHubVerificationIcon(
+                              item.value.verification_status
+                            )
+                          "
+                        />
+                      </template>
+                    </v-tooltip>
                     <span v-else>-</span>
                   </div>
                 </template>
                 <template v-slot:[`item.status_gitleaks`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.gitleaksSetting)"
-                    v-if="getStatus(item.value.gitleaksSetting)"
-                  >
-                  </scan-status>
-                  <v-chip variant="flat" color="grey" v-else> Disabled </v-chip>
+                    icon-only
+                  />
                 </template>
                 <template v-slot:[`item.status_dependency`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.dependencySetting)"
-                    v-if="getStatus(item.value.dependencySetting)"
-                  >
-                  </scan-status>
-                  <v-chip variant="flat" color="grey" v-else> Disabled </v-chip>
+                    icon-only
+                  />
                 </template>
                 <template v-slot:[`item.status_code_scan`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.codeScanSetting)"
-                    v-if="getStatus(item.value.codeScanSetting)"
-                  >
-                  </scan-status>
-                  <v-chip variant="flat" color="grey" v-else> Disabled </v-chip>
+                    icon-only
+                  />
                 </template>
                 <template v-slot:[`item.action`]="{ item }">
                   <v-menu>
@@ -940,16 +938,18 @@ export default {
   font-size: 12px;
 }
 
-.github-setting-table :deep(thead th) {
+.github-setting-table :deep(thead th .v-data-table-header__content) {
   white-space: nowrap;
 }
 
-.github-setting-table :deep(thead th.status-split-header) {
-  white-space: normal;
-}
-
 .github-setting-table
-  :deep(thead th.status-split-header .v-data-table-header__content) {
+  :deep(thead th:nth-child(4) .v-data-table-header__content),
+.github-setting-table
+  :deep(thead th:nth-child(7) .v-data-table-header__content),
+.github-setting-table
+  :deep(thead th:nth-child(8) .v-data-table-header__content),
+.github-setting-table
+  :deep(thead th:nth-child(9) .v-data-table-header__content) {
   white-space: pre;
 }
 


### PR DESCRIPTION
## PRの概要

GitHub設定一覧に表示される GitHub App、Gitleaks、Dependency、Code Scan のステータスを、状態を判別しやすいアイコン表示へ統一します。

各アイコンにはツールチップを設定し、マウスオーバー時にステータスの内容を確認できるようにします。また、ステータス列のヘッダーを名称と「ステータス」の2行表示に調整します。

## 背景

### 【目的】

GitHub設定一覧のステータス表示によるカラムの表示崩れを解消し、各状態をコンパクトに表示することを目的とします。

### 【経緯】

従来の文字付きチップでは、Gitleaks、Dependency、Code Scan のステータス列が横幅を必要とし、GitHub設定一覧のカラムに表示崩れが発生していました。

### 【経緯を踏まえた方針】

既存のステータスごとの色とアイコンを利用し、一覧ではアイコンだけを表示します。

文字情報は失われないよう、ターゲット種別アイコンと同じ形式のツールチップで補足します。GitHub Appステータスについても同じ操作感に統一します。

## 修正点

| 変更点 | 内容 |
|---|---|
| スキャンステータス | Gitleaks、Dependency、Code Scan の状態をアイコンで表示 |
| GitHub Appステータス | アイコンへのマウスオーバーで連携状態を表示 |
| ツールチップ | ステータスアイコンの値を上部ツールチップで表示 |
| 無効状態 | 未設定・無効状態を灰色のマイナスアイコンで表示 |
| ヘッダー表示 | GitHub Appおよび各スキャンのステータス列を2行表示 |
| 既存表示との互換性 | GitHub設定一覧以外では従来のステータスチップ表示を維持 |

## 重点レビューポイント

- OK・設定中・処理中・エラー・無効の各状態に、適切なアイコンと色が割り当てられているかどうか
- GitHub Appおよび各スキャンのツールチップが、ターゲット種別アイコンの操作感と整合しているかどうか
- ステータス列ヘッダーの2行表示が、他のカラムを意図せず改行させていないかどうか
- 既存のステータスコンポーネントを利用する他画面の表示に影響しないかどうか

## 動作確認

以下のコマンドが成功することを確認しました。

- `pnpm lint`
- `pnpm build-prd`
- `make build`

Docker Desktop上のKubernetes環境へ反映し、以下を画面で確認しました。

- Gitleaks、Dependency、Code Scan のステータスがアイコンで表示されること
- GitHub Appおよび各スキャンのステータスアイコンにツールチップが設定されていること
- GitHub Appおよび各スキャンのステータス列ヘッダーが2行表示になること
- ステータス以外の列が不要に改行されないこと
