### PR TITLE
GitHub設定一覧のステータスをアイコン表示に変更

### DIFF
--- a/src/component/widget/datasource/Status.vue
+++ b/src/component/widget/datasource/Status.vue
@@ -1,6 +1,33 @@
 <template>
+  <template v-if="iconOnly">
+    <v-tooltip
+      :text="status ? getDataSourceStatusText(status) : 'Disabled'"
+      location="top"
+    >
+      <template v-slot:activator="{ props }">
+        <v-progress-circular
+          v-if="isInProgressDataSourceStatus(status)"
+          v-bind="props"
+          indeterminate
+          size="24"
+          width="3"
+          color="cyan"
+        />
+        <v-icon
+          v-else
+          v-bind="props"
+          :color="status ? getDataSourceStatusColor(status) : 'grey'"
+          :icon="
+            status
+              ? getDataSourceStatusIcon(status)
+              : 'mdi-minus-circle-outline'
+          "
+        />
+      </template>
+    </v-tooltip>
+  </template>
   <v-chip
-    v-if="true"
+    v-else
     :color="getDataSourceStatusColor(status)"
     variant="flat"
     class="text-white"
@@ -18,7 +45,6 @@
     }}</v-icon>
     {{ getDataSourceStatusText(status) }}
   </v-chip>
-  <v-chip v-else color="grey" variant="flat">Not configured</v-chip>
 </template>
 
 <script>
@@ -27,6 +53,10 @@ export default {
   mixins: [mixin],
   name: 'DataSourceStatus',
   props: {
+    iconOnly: {
+      type: Boolean,
+      default: false,
+    },
     status: {
       type: Number,
       default: 0,

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -122,55 +122,53 @@
                 </template>
                 <template v-slot:[`item.verification_status`]="{ item }">
                   <div class="github-app-status-icon">
-                    <v-icon
+                    <v-tooltip
                       v-if="item.value.auth_mode === 'GITHUB_APP'"
-                      :color="
-                        getGitHubVerificationColor(
+                      :text="
+                        getGitHubVerificationText(
                           item.value.auth_mode,
                           item.value.verification_status
                         )
                       "
-                      :icon="
-                        getGitHubVerificationIcon(
-                          item.value.verification_status
-                        )
-                      "
+                      location="top"
                     >
-                      <v-tooltip activator="parent" location="bottom">
-                        {{
-                          getGitHubVerificationText(
-                            item.value.auth_mode,
-                            item.value.verification_status
-                          )
-                        }}
-                      </v-tooltip>
-                    </v-icon>
+                      <template v-slot:activator="{ props }">
+                        <v-icon
+                          v-bind="props"
+                          :color="
+                            getGitHubVerificationColor(
+                              item.value.auth_mode,
+                              item.value.verification_status
+                            )
+                          "
+                          :icon="
+                            getGitHubVerificationIcon(
+                              item.value.verification_status
+                            )
+                          "
+                        />
+                      </template>
+                    </v-tooltip>
                     <span v-else>-</span>
                   </div>
                 </template>
                 <template v-slot:[`item.status_gitleaks`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.gitleaksSetting)"
-                    v-if="getStatus(item.value.gitleaksSetting)"
-                  >
-                  </scan-status>
-                  <v-chip variant="flat" color="grey" v-else> Disabled </v-chip>
+                    icon-only
+                  />
                 </template>
                 <template v-slot:[`item.status_dependency`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.dependencySetting)"
-                    v-if="getStatus(item.value.dependencySetting)"
-                  >
-                  </scan-status>
-                  <v-chip variant="flat" color="grey" v-else> Disabled </v-chip>
+                    icon-only
+                  />
                 </template>
                 <template v-slot:[`item.status_code_scan`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.codeScanSetting)"
-                    v-if="getStatus(item.value.codeScanSetting)"
-                  >
-                  </scan-status>
-                  <v-chip variant="flat" color="grey" v-else> Disabled </v-chip>
+                    icon-only
+                  />
                 </template>
                 <template v-slot:[`item.action`]="{ item }">
                   <v-menu>


### PR DESCRIPTION
## 変更内容

- GitHub設定一覧の GitHub App、Gitleaks、Dependency、Code Scan のステータスをアイコン表示に変更
- 各ステータスアイコンにマウスオーバーすると、現在のステータスを文字で表示
- 未設定のスキャンは灰色のアイコンで表示

## 背景

ステータスをチップと文字で表示すると一覧のカラム幅が広がり、表示崩れが起きるため、情報を維持したまま表示をコンパクトにします。

## 影響

GitHub設定一覧の表示のみが対象です。既存の他画面で使用しているステータスチップ表示は維持します。

## 検証

- `pnpm lint`
- `pnpm build-prd`
- `make build`
- Docker Desktop の Kubernetes 環境へ反映し、アイコン表示を確認
- GitHub App、Gitleaks、Dependency、Code Scan の各アイコンにステータス文字のツールチップが紐づくことを確認
