### PR TITLE
GitHub設定一覧のステータス表示をコンパクトに調整

### DIFF
--- a/src/component/widget/datasource/Status.vue
+++ b/src/component/widget/datasource/Status.vue
@@ -1,33 +1,6 @@
 <template>
-  <template v-if="iconOnly">
-    <v-tooltip
-      :text="status ? getDataSourceStatusText(status) : 'Disabled'"
-      location="top"
-    >
-      <template v-slot:activator="{ props }">
-        <v-progress-circular
-          v-if="isInProgressDataSourceStatus(status)"
-          v-bind="props"
-          indeterminate
-          size="24"
-          width="3"
-          color="cyan"
-        />
-        <v-icon
-          v-else
-          v-bind="props"
-          :color="status ? getDataSourceStatusColor(status) : 'grey'"
-          :icon="
-            status
-              ? getDataSourceStatusIcon(status)
-              : 'mdi-minus-circle-outline'
-          "
-        />
-      </template>
-    </v-tooltip>
-  </template>
   <v-chip
-    v-else
+    v-if="true"
     :color="getDataSourceStatusColor(status)"
     variant="flat"
     class="text-white"
@@ -45,6 +18,7 @@
     }}</v-icon>
     {{ getDataSourceStatusText(status) }}
   </v-chip>
+  <v-chip v-else color="grey" variant="flat">Not configured</v-chip>
 </template>
 
 <script>
@@ -53,10 +27,6 @@ export default {
   mixins: [mixin],
   name: 'DataSourceStatus',
   props: {
-    iconOnly: {
-      type: Boolean,
-      default: false,
-    },
     status: {
       type: Number,
       default: 0,

--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -155,20 +155,50 @@
                 <template v-slot:[`item.status_gitleaks`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.gitleaksSetting)"
-                    icon-only
+                    v-if="getStatus(item.value.gitleaksSetting)"
+                    class="github-scan-status"
                   />
+                  <v-chip
+                    v-else
+                    variant="flat"
+                    color="grey"
+                    class="github-scan-status"
+                  >
+                    <v-icon>mdi-minus-circle-outline</v-icon>
+                    Disabled
+                  </v-chip>
                 </template>
                 <template v-slot:[`item.status_dependency`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.dependencySetting)"
-                    icon-only
+                    v-if="getStatus(item.value.dependencySetting)"
+                    class="github-scan-status"
                   />
+                  <v-chip
+                    v-else
+                    variant="flat"
+                    color="grey"
+                    class="github-scan-status"
+                  >
+                    <v-icon>mdi-minus-circle-outline</v-icon>
+                    Disabled
+                  </v-chip>
                 </template>
                 <template v-slot:[`item.status_code_scan`]="{ item }">
                   <scan-status
                     :status="getStatus(item.value.codeScanSetting)"
-                    icon-only
+                    v-if="getStatus(item.value.codeScanSetting)"
+                    class="github-scan-status"
                   />
+                  <v-chip
+                    v-else
+                    variant="flat"
+                    color="grey"
+                    class="github-scan-status"
+                  >
+                    <v-icon>mdi-minus-circle-outline</v-icon>
+                    Disabled
+                  </v-chip>
                 </template>
                 <template v-slot:[`item.action`]="{ item }">
                   <v-menu>
@@ -943,5 +973,14 @@ export default {
   display: flex;
   justify-content: center;
   width: 100%;
+}
+
+.github-setting-table :deep(.github-scan-status) {
+  font-size: 11px;
+  padding-inline: 8px;
+}
+
+.github-setting-table :deep(.github-scan-status .v-icon) {
+  margin-right: 2px !important;
 }
 </style>


### PR DESCRIPTION
## 変更内容

- Gitleaks、Dependency、Code Scan のステータスをアイコンと文字のチップ表示へ変更
- ステータス文字を11pxへ縮小
- アイコンと文字の間隔を2pxへ縮小
- 未設定状態もアイコンと `Disabled` の組み合わせで表示

## 背景

アイコンのみでは状態を直接判別しづらいため、文字を併記しつつ、`Configured` などの長い値でも一覧のカラムを圧迫しにくい表示へ調整します。

## 影響

GitHub設定一覧のスキャンステータス3列のみが対象です。

## 検証

- `pnpm prettier --check src`
- `pnpm lint`
- `pnpm build-prd`
- `make build`
- Docker Desktop の Kubernetes 環境へ反映し、アイコン＋文字の表示を確認
- 文字サイズ11px、左右パディング8px、アイコン右余白2pxを確認
