### PR TITLE
GitHub連携前にAppインストール状態を再検証する

### DIFF
--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -1821,6 +1821,22 @@ export default {
     },
     async handleGitHubAppUserVerification() {
       this.loading = true
+      const gitHubSetting = await this.verifyGitHubAppInstallationAPI(
+        this.gitHubSetting.github_setting_id
+      ).catch(async (err) => {
+        this.$emit('edit-notify', '', this.getErrorMessage(err))
+        await this.refreshGitHubAppInstallationStatus()
+        return null
+      })
+      if (gitHubSetting === null) {
+        this.loading = false
+        return
+      }
+      if (!this.applyGitHubSetting(gitHubSetting)) {
+        this.$emit('edit-notify', '', 'GitHub setting response is invalid.')
+        this.loading = false
+        return
+      }
       const returnTo = this.buildGitHubAppOAuthReturnTo()
       const oauthURL = await this.getGitHubAppOAuthStartURLAPI(
         this.gitHubSetting.github_setting_id,


### PR DESCRIPTION
## PRの概要

GitHub Appを設定保存した後にAppをインストールした場合、設定に `installation_id` が反映されないままGitHub OAuthへ進み、コールバック後のユーザー検証が失敗していました。

「GitHub連携」押下時にAppのインストール検証を先に実行し、返却されたGitHub設定を画面へ反映できた場合だけOAuthを開始するよう変更します。

検証に失敗した場合はOAuthへ遷移せず、インストール状態を再取得して現在の状態を画面へ反映します。

| 条件 | 変更前 | 変更後 |
| --- | --- | --- |
| Appインストール済み・`installation_id`未反映 | OAuthコールバック後に連携失敗 | インストール検証でIDを反映してからOAuth開始 |
| App未インストール・検証失敗 | OAuth開始を試行 | 画面に留まり状態を再表示 |

## レビュー観点例

- [ ] インストール検証成功後にのみOAuth開始処理へ進む点
- [ ] 検証APIの返却設定から `installation_id` を含む最新状態が反映される点
- [ ] 検証失敗時にOAuthへ遷移せず、画面のインストール状態が更新される点
- [ ] 既存の再同期処理やGitHub設定保存処理へ影響を与えない最小差分である点