### PR TITLE
GitHub設定表示時にAppの現在状態を確認する

### DIFF
--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -1267,7 +1267,7 @@ export default {
     },
   },
   mounted() {
-    this.refreshGitHubAppInstallationStatusForReadOnly()
+    this.refreshGitHubAppInstallationStatusForConfiguredSetting()
   },
   watch: {
     isEnabledGitleaks: function () {
@@ -1684,13 +1684,8 @@ export default {
           return null
         })
     },
-    async refreshGitHubAppInstallationStatusForReadOnly() {
-      if (
-        !this.isReadOnly ||
-        !this.isConfiguredGitHubSetting ||
-        !this.isGitHubAppAuth ||
-        this.gitHubSetting.verification_status !== 'FAILED'
-      ) {
+    async refreshGitHubAppInstallationStatusForConfiguredSetting() {
+      if (!this.isConfiguredGitHubSetting || !this.isGitHubAppAuth) {
         return
       }
       await this.refreshGitHubAppInstallationStatus()

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -240,13 +240,13 @@
                             variant="flat"
                             :color="
                               getGitHubVerificationColor(
-                                gitHubSetting.verification_status
+                                displayedGitHubVerificationStatus
                               )
                             "
                           >
                             {{
                               getGitHubVerificationText(
-                                gitHubSetting.verification_status
+                                displayedGitHubVerificationStatus
                               )
                             }}
                           </v-chip>
@@ -1185,6 +1185,12 @@ export default {
         this.isGitHubAppAuth &&
         this.gitHubSetting.verification_status === 'SUCCESS'
       )
+    },
+    displayedGitHubVerificationStatus() {
+      if (this.githubAppInstallationStatus?.reason === 'NOT_INSTALLED') {
+        return 'FAILED'
+      }
+      return this.gitHubSetting.verification_status
     },
     isGitHubAppLinkPending() {
       return (


### PR DESCRIPTION
## PRの概要

GitHub App連携成功後にAppがアンインストールされても、保存済みの連携成功ステータスが詳細・編集画面に残り続けていました。

設定済みのGitHub Appについて、詳細画面または設定編集画面を開くたびに読み取り専用のインストール状態確認APIを実行するよう変更します。

GitHub側でAppが見つからない場合は、既存の警告表示を利用して「GitHub Appは未インストールです。」と表示します。

| 条件 | 変更前 | 変更後 |
| --- | --- | --- |
| 連携成功後にAppをアンインストール | 連携成功表示が残る | 画面を開いた時に未インストール警告を表示 |
| Appがインストール済み | 保存済み状態を表示 | 現在のインストール済み状態を表示 |
| 状態確認に失敗 | FAILED設定の詳細表示時のみエラー表示 | 詳細・編集の両方で確認失敗を表示 |

## レビュー観点例

- [ ] 詳細画面と設定編集画面の両方で現在のインストール状態を取得する点
- [ ] GitHub App以外や未保存の設定では状態確認APIを呼ばない点
- [ ] 読み取り専用APIのみを利用し、保存済みの連携状態を暗黙に更新しない点
- [ ] GitHub APIとの通信失敗とApp未インストールを既存の理由コードで区別する点