### PR TITLE
GitHub App未インストール状態を一覧に反映

### DIFF
--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -283,6 +283,9 @@
       :codeScanDataSourceModel="codeScanDataSourceModel"
       @closeDialog="closeDialogEdit"
       @editGitHubSetting="handleEditGitHubSettingFromDetail"
+      @github-app-installation-status-updated="
+        handleGitHubAppInstallationStatusUpdated
+      "
       v-on:edit-notify="handleEditFinish"
     ></setting-dialog>
 
@@ -334,6 +337,7 @@ export default {
         updated_at: '',
       },
       githubAppOAuthResult: null,
+      githubAppVerificationStatusOverrides: {},
       gitHubModel: {
         github_setting_id: '',
         code_data_source_id: '',
@@ -559,7 +563,10 @@ export default {
               ? 'PERSONAL_ACCESS_TOKEN'
               : github_setting.auth_mode,
           installation_id: github_setting.installation_id,
-          verification_status: github_setting.verification_status,
+          verification_status:
+            this.githubAppVerificationStatusOverrides[
+              github_setting.github_setting_id
+            ] || github_setting.verification_status,
           verified_github_user: github_setting.verified_github_user,
           verified_at: github_setting.verified_at,
           github_app_setting_repository:
@@ -852,6 +859,26 @@ export default {
     },
     handleEditGitHubSettingFromDetail() {
       this.isReadOnlyForm = false
+    },
+    handleGitHubAppInstallationStatusUpdated({ github_setting_id, status }) {
+      if (!github_setting_id || !status) {
+        return
+      }
+      if (status.reason === 'NOT_INSTALLED') {
+        this.githubAppVerificationStatusOverrides[github_setting_id] = 'FAILED'
+        const item = this.table.items.find(
+          (setting) => setting.github_setting_id === github_setting_id
+        )
+        if (item) {
+          item.verification_status = 'FAILED'
+        }
+        return
+      }
+      if (!status.installed) {
+        return
+      }
+      delete this.githubAppVerificationStatusOverrides[github_setting_id]
+      this.listGitHubSetting()
     },
     handleDeleteGitHubSetting(item) {
       this.assignDataModel(item.value)

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -1689,6 +1689,12 @@ export default {
           this.$emit('edit-notify', '', this.getErrorMessage(err))
           return null
         })
+      if (this.githubAppInstallationStatus) {
+        this.$emit('github-app-installation-status-updated', {
+          github_setting_id: this.gitHubSetting.github_setting_id,
+          status: this.githubAppInstallationStatus,
+        })
+      }
     },
     async refreshGitHubAppInstallationStatusForConfiguredSetting() {
       if (!this.isConfiguredGitHubSetting || !this.isGitHubAppAuth) {


### PR DESCRIPTION
## PRの概要

GitHub Appのアンインストールを設定詳細画面で検出しても、一覧の定期再取得によってバックエンドに保存された連携成功ステータスへ戻ってしまう問題を解消します。

詳細ダイアログで確認した未インストール状態をGitHub Setting ID単位で親画面へ通知し、一覧では画面内オーバーライドとして連携失敗を維持します。

再インストール済みであることを確認できた場合にだけオーバーライドを解除し、状態確認自体が失敗した場合は既知の未インストール状態を保持します。

| 状態確認結果 | 一覧表示 |
| --- | --- |
| 未インストール | 連携失敗を維持 |
| 再インストール済み | オーバーライドを解除して最新状態を再取得 |
| 状態確認失敗 | 既知の表示を維持 |

## レビュー観点例

- [ ] 未インストール判定がGitHub Setting ID単位でのみ反映される点
- [ ] 定期再取得後も画面内オーバーライドが維持される点
- [ ] 再インストール成功時にのみオーバーライドを解除する点
- [ ] 状態確認失敗時に既知の未インストール状態を誤って解除しない点