### PR TITLE
GitHub App確認後に永続化された連携状態を再取得

### DIFF
--- a/src/view/code/GitHub.vue
+++ b/src/view/code/GitHub.vue
@@ -283,9 +283,7 @@
       :codeScanDataSourceModel="codeScanDataSourceModel"
       @closeDialog="closeDialogEdit"
       @editGitHubSetting="handleEditGitHubSettingFromDetail"
-      @github-app-installation-status-updated="
-        handleGitHubAppInstallationStatusUpdated
-      "
+      @github-app-installation-status-updated="listGitHubSetting"
       v-on:edit-notify="handleEditFinish"
     ></setting-dialog>
 
@@ -337,7 +335,6 @@ export default {
         updated_at: '',
       },
       githubAppOAuthResult: null,
-      githubAppVerificationStatusOverrides: {},
       gitHubModel: {
         github_setting_id: '',
         code_data_source_id: '',
@@ -563,10 +560,7 @@ export default {
               ? 'PERSONAL_ACCESS_TOKEN'
               : github_setting.auth_mode,
           installation_id: github_setting.installation_id,
-          verification_status:
-            this.githubAppVerificationStatusOverrides[
-              github_setting.github_setting_id
-            ] || github_setting.verification_status,
+          verification_status: github_setting.verification_status,
           verified_github_user: github_setting.verified_github_user,
           verified_at: github_setting.verified_at,
           github_app_setting_repository:
@@ -859,26 +853,6 @@ export default {
     },
     handleEditGitHubSettingFromDetail() {
       this.isReadOnlyForm = false
-    },
-    handleGitHubAppInstallationStatusUpdated({ github_setting_id, status }) {
-      if (!github_setting_id || !status) {
-        return
-      }
-      if (status.reason === 'NOT_INSTALLED') {
-        this.githubAppVerificationStatusOverrides[github_setting_id] = 'FAILED'
-        const item = this.table.items.find(
-          (setting) => setting.github_setting_id === github_setting_id
-        )
-        if (item) {
-          item.verification_status = 'FAILED'
-        }
-        return
-      }
-      if (!status.installed) {
-        return
-      }
-      delete this.githubAppVerificationStatusOverrides[github_setting_id]
-      this.listGitHubSetting()
     },
     handleDeleteGitHubSetting(item) {
       this.assignDataModel(item.value)


### PR DESCRIPTION
## PRの概要

GitHub Appのインストール状態を詳細画面で確認した後、一覧へ戻ると古い連携状態が残る問題を解消します。

datasource-apiが検証結果を永続化する方針に合わせ、フロントエンド内の一時的なステータス上書きを廃止し、インストール状態の更新イベントを受けた際にGitHub設定一覧を再取得します。

これにより、画面セッション内の状態ではなく、バックエンドに保存された検証状態を一覧表示の正として扱います。

| 状態確認後の一覧表示 | 変更前 | 変更後 |
|---|---|---|
| GitHub App未インストール | フロントエンドの一時上書きで失敗表示 | バックエンドへ再問い合わせして保存済み状態を表示 |
| 再取得・画面遷移 | 一時上書きの管理が必要 | APIレスポンスのみで表示を決定 |

## レビュー観点例

- [ ] インストール状態更新イベントごとに一覧APIを再取得する負荷の点
- [ ] フロントエンドの一時上書き廃止後も詳細画面から一覧へ戻った際に状態が同期される点
- [ ] datasource-api側の状態永続化を表示の正とする責務分離の点
- [ ] 一覧再取得に失敗した場合の既存エラー表示を維持する点