### PR TITLE
GitHub App連携処理の多重実行を防止

### DIFF
--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -215,7 +215,15 @@
                           <span>{{
                             $t(`item['GitHub App Link Pending Action Prefix']`)
                           }}</span
+                          ><span
+                            v-if="
+                              loading || githubAppInstallationStatusLoading
+                            "
+                            >{{
+                              $t(`item['GitHub App Link Pending Action Link']`)
+                            }}</span
                           ><a
+                            v-else
                             href="#"
                             @click.prevent="handleGitHubAppLinkFromDetail"
                             >{{
@@ -330,7 +338,10 @@
                         isGitHubAppAuth &&
                         isConfiguredGitHubSetting
                       "
-                      :loading="loading"
+                      :loading="loading || githubAppInstallationStatusLoading"
+                      :disabled="
+                        loading || githubAppInstallationStatusLoading
+                      "
                     >
                       {{ $t(`btn['VERIFY GITHUB USER']`) }}
                     </v-btn>
@@ -1333,6 +1344,7 @@ export default {
       gitleaksCacheDialog: false,
       githubAppRepositoryDialog: false,
       githubAppInstallationStatus: null,
+      githubAppInstallationStatusLoading: false,
       githubSettingID: 0,
       loading: false,
       gitHubForm: {
@@ -1682,18 +1694,33 @@ export default {
       return gitHubSetting
     },
     async refreshGitHubAppInstallationStatus() {
-      this.githubAppInstallationStatus =
-        await this.getGitHubAppInstallationStatusAPI(
-          this.gitHubSetting.github_setting_id
-        ).catch((err) => {
-          this.$emit('edit-notify', '', this.getErrorMessage(err))
-          return null
-        })
-      if (this.githubAppInstallationStatus) {
-        this.$emit('github-app-installation-status-updated', {
-          github_setting_id: this.gitHubSetting.github_setting_id,
-          status: this.githubAppInstallationStatus,
-        })
+      if (this.githubAppInstallationStatusLoading) {
+        return
+      }
+      this.githubAppInstallationStatusLoading = true
+      try {
+        this.githubAppInstallationStatus =
+          await this.getGitHubAppInstallationStatusAPI(
+            this.gitHubSetting.github_setting_id
+          ).catch((err) => {
+            this.$emit('edit-notify', '', this.getErrorMessage(err))
+            return null
+          })
+        if (this.githubAppInstallationStatus) {
+          if (
+            this.githubAppInstallationStatus.reason === 'INSTALLED' &&
+            this.gitHubSetting.verification_status === 'FAILED'
+          ) {
+            this.gitHubSetting.verification_status =
+              'PENDING_USER_VERIFICATION'
+          }
+          this.$emit('github-app-installation-status-updated', {
+            github_setting_id: this.gitHubSetting.github_setting_id,
+            status: this.githubAppInstallationStatus,
+          })
+        }
+      } finally {
+        this.githubAppInstallationStatusLoading = false
       }
     },
     async refreshGitHubAppInstallationStatusForConfiguredSetting() {
@@ -1827,6 +1854,9 @@ export default {
       }
     },
     async handleGitHubAppUserVerification() {
+      if (this.loading || this.githubAppInstallationStatusLoading) {
+        return
+      }
       this.loading = true
       const gitHubSetting = await this.verifyGitHubAppInstallationAPI(
         this.gitHubSetting.github_setting_id
@@ -1848,24 +1878,25 @@ export default {
       const oauthURL = await this.getGitHubAppOAuthStartURLAPI(
         this.gitHubSetting.github_setting_id,
         returnTo
-      )
-        .catch((err) => {
-          this.$emit('edit-notify', '', this.getErrorMessage(err))
-          return ''
-        })
-        .finally(() => {
-          this.loading = false
-        })
+      ).catch((err) => {
+        this.$emit('edit-notify', '', this.getErrorMessage(err))
+        return ''
+      })
       if (!oauthURL) {
+        this.loading = false
         return
       }
       if (!this.isAllowedGitHubAppOAuthURL(oauthURL)) {
         this.$emit('edit-notify', '', 'GitHub App OAuth URL is invalid.')
+        this.loading = false
         return
       }
       window.location.href = oauthURL
     },
     async handleGitHubAppLinkFromDetail() {
+      if (this.loading || this.githubAppInstallationStatusLoading) {
+        return
+      }
       this.loading = true
       const gitHubSetting = await this.verifyGitHubAppInstallationAPI(
         this.gitHubSetting.github_setting_id

--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -216,9 +216,7 @@
                             $t(`item['GitHub App Link Pending Action Prefix']`)
                           }}</span
                           ><span
-                            v-if="
-                              loading || githubAppInstallationStatusLoading
-                            "
+                            v-if="loading || githubAppInstallationStatusLoading"
                             >{{
                               $t(`item['GitHub App Link Pending Action Link']`)
                             }}</span
@@ -339,9 +337,7 @@
                         isConfiguredGitHubSetting
                       "
                       :loading="loading || githubAppInstallationStatusLoading"
-                      :disabled="
-                        loading || githubAppInstallationStatusLoading
-                      "
+                      :disabled="loading || githubAppInstallationStatusLoading"
                     >
                       {{ $t(`btn['VERIFY GITHUB USER']`) }}
                     </v-btn>
@@ -1711,8 +1707,7 @@ export default {
             this.githubAppInstallationStatus.reason === 'INSTALLED' &&
             this.gitHubSetting.verification_status === 'FAILED'
           ) {
-            this.gitHubSetting.verification_status =
-              'PENDING_USER_VERIFICATION'
+            this.gitHubSetting.verification_status = 'PENDING_USER_VERIFICATION'
           }
           this.$emit('github-app-installation-status-updated', {
             github_setting_id: this.gitHubSetting.github_setting_id,


### PR DESCRIPTION
## PRの概要

GitHub Appのインストール状態確認中やOAuth認可画面への遷移直前に「GitHub連携」を再度操作でき、同じ処理が重複実行される問題を防止します。

インストール状態確認専用のローディング状態を追加し、確認中はボタンを無効化するとともに、詳細画面のリンクを操作不能なテキストとして表示します。

また、再インストールを検出してバックエンドが連携状態を更新した場合は、開いている詳細画面も即座に「GitHub連携待ち」へ更新します。

OAuth URL取得後は、失敗時のみローディングを解除し、成功時は画面遷移が始まるまで操作不能状態を維持します。

| 状況 | 変更前 | 変更後 |
| --- | --- | --- |
| インストール状態確認中 | GitHub連携を再操作できる場合がある | 確認完了まで操作不能 |
| 再インストール検出後 | 詳細画面を閉じるまで連携失敗表示 | 開いたままGitHub連携待ちへ更新 |
| OAuth遷移直前 | 一瞬ボタンが再有効化 | 遷移開始までローディングを維持 |

## レビュー観点例

- [ ] インストール状態確認中の多重実行防止条件が既存の保存・連携フローを妨げない点
- [ ] 再インストール検出時のみローカル表示をGitHub連携待ちへ更新する条件がバックエンドの状態遷移と一致する点
- [ ] OAuth URL取得失敗および不正URL検出時に操作可能な状態へ復帰する点
- [ ] OAuth URL取得成功後に画面遷移までローディングを維持しても操作不能状態が残留しない点
