### PR TITLE
GitHub Appインストール済みInfoの表示条件を整理

### DIFF
--- a/src/view/code/SettingDialog.vue
+++ b/src/view/code/SettingDialog.vue
@@ -176,7 +176,12 @@
                       ></v-text-field>
                     </v-col>
                   </v-row>
-                  <v-row v-if="isGitHubAppAuth && githubAppInstallationStatus">
+                  <v-row
+                    v-if="
+                      isGitHubAppAuth &&
+                      shouldShowGitHubAppInstallationStatusAlert
+                    "
+                  >
                     <v-col cols="12">
                       <v-alert
                         density="compact"
@@ -1254,6 +1259,17 @@ export default {
         return 'github-app-installation-warning'
       }
       return ''
+    },
+    shouldShowGitHubAppInstallationStatusAlert() {
+      if (!this.githubAppInstallationStatus) {
+        return false
+      }
+      if (!this.githubAppInstallationStatus.installed) {
+        return true
+      }
+      return !['SUCCESS', 'PENDING_USER_VERIFICATION', 'PENDING'].includes(
+        this.gitHubSetting.verification_status
+      )
     },
     shouldShowGitHubAppInstallPageLink() {
       return this.githubAppInstallationStatus?.reason === 'NOT_INSTALLED'


### PR DESCRIPTION
## PRの概要

GitHub Appがインストール済みの場合に表示していた案内Infoが、連携成功時およびGitHub連携待ちのステータス表示と重複していたため、表示条件を整理します。

連携成功、GitHub連携待ち、連携処理中ではインストール済みInfoを表示せず、未インストールや状態確認失敗など、追加対応を案内する必要がある場合は従来どおり表示します。

| GitHub App状態 | Info表示 |
| --- | --- |
| 連携成功 | 非表示 |
| GitHub連携待ち | 非表示 |
| 未インストール | 表示 |
| 状態確認失敗 | 表示 |

## レビュー観点例

- [ ] 連携成功およびGitHub連携待ちで重複するInfoが表示されない点
- [ ] 未インストール時のインストール画面への案内が維持される点
- [ ] 状態確認失敗時のエラー案内が維持される点
- [ ] 未知の連携ステータスでは案内を隠さず従来表示を維持する点
